### PR TITLE
Fixed purge paths for virtual hosting scenarios using virtual path components.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.1.2 (unreleased)
 ~~~~~~~~~~~~~~~~~~
 
-- Nothing changed yet.
+- Fixed purge paths for virtual hosting scenarios using virtual path components.
+  [dokai]
 
 
 1.1.1 (2012-08-30)
@@ -40,23 +41,23 @@ Changelog
 
 1.0.2 (2012-04-15)
 ~~~~~~~~~~~~~~~~~~
-- Handle caching of resource registries in RAM cache by not storing empty 
+- Handle caching of resource registries in RAM cache by not storing empty
   bodies in the RAMCache
   [eleddy with major tseaver support]
 
 
 1.0.1 (2012-01-26)
 ~~~~~~~~~~~~~~~~~~
-- Properly handle a changed configuration from with etags to no etags by 
+- Properly handle a changed configuration from with etags to no etags by
   forcing a page refresh
   [eleddy]
 
 - When not caching with etags, don't sent an etag header to stop caching
   [eleddy]
 
-- When there was an error like Unauthorized, 200 status and empty body would be 
-  cached in RAMCache instead of not caching anything. 
-  This is due to a bug with Zope 2.13 publication events : 
+- When there was an error like Unauthorized, 200 status and empty body would be
+  cached in RAMCache instead of not caching anything.
+  This is due to a bug with Zope 2.13 publication events :
   response.status is not set when IPubBeforeAbort is notified.
   Fixed by using error_status stored on request by plone.transformchain.
   [gotcha]

--- a/plone/app/caching/purge.py
+++ b/plone/app/caching/purge.py
@@ -53,7 +53,7 @@ class ContentPurgePaths(object):
         self.context = context
 
     def getRelativePaths(self):
-        prefix = self.context.absolute_url_path()
+        prefix = '/' + self.context.virtual_url_path()
 
         yield prefix + '/'
         yield prefix + '/view'
@@ -66,7 +66,7 @@ class ContentPurgePaths(object):
         if parent is not None:
             parentDefaultView = getObjectDefaultView(parent)
             if parentDefaultView == self.context.getId():
-                parentPrefix = parent.absolute_url_path()
+                parentPrefix = '/' + parent.virtual_url_path()
                 yield parentPrefix
                 yield parentPrefix + '/'
                 yield parentPrefix + '/view'
@@ -151,7 +151,7 @@ if HAVE_AT:
             self.context = context
 
         def getRelativePaths(self):
-            prefix = self.context.absolute_url_path()
+            prefix = '/' + self.context.virtual_url_path()
             schema = self.context.Schema()
 
             def fieldFilter(field):


### PR DESCRIPTION
...nents.

In case the virtual host setup includes virtual path components which are not
part of the ZODB path hierarchy, the generated purge paths are incorrect.

For example, assuming the following rewrite rule in Apache

  RewriteRule ^/a/b/?(.*)/?$ http://127.0.0.1:5128/VirtualHostBase/http/%{SERVER_NAME}:80/VirtualHostRoot/_vh_a/_vh_b/$1 [P,L]

which contains a two-part virtual path `/a/b` results in the following kind of
of URL to be sent to Varnish

  /VirtualHostBase/http/server.com:80/VirtualHostRoot/_vh_a/_vh_b/plone/my-document

however, when the purge URLs are generated using the `absolute_url_path`
method they look like

  /VirtualHostBase/http/server.com:80/VirtualHostRoot/_vh_a/_vh_b/a/b/plone/my-document

containing the virtual "/a/b" part which does not match with what gets cached in
Varnish.

Instead of using `absolute_url_path` the `virtual_url_path` method should be
used instead to avoid the virtual parts.

Note that `virtual_url_path` does not have a leading slash which needs to be
added explicitly.
