### PR TITLE
ramcache transformIterable mustn't return None if it reads the iterable input

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 1.1.2 (unreleased)
 ~~~~~~~~~~~~~~~~~~
 
-- Nothing changed yet.
+- Fix bug `12038 <https://dev.plone.org/ticket/12038>`_ [ebrehault]
 
 
 1.1.1 (2012-08-30)

--- a/plone/app/caching/operations/ramcache.py
+++ b/plone/app/caching/operations/ramcache.py
@@ -42,8 +42,11 @@ class Store(object):
 
     def transformIterable(self, result, encoding):
         if self.responseIsSuccess() and IRAMCached.providedBy(self.request):
+            result = ''.join(result)
             storeResponseInRAMCache(self.request, self.request.response,
-                    ''.join(result))
+                result)
+            # as we have iterated the iterable, we must return a new one
+            return iter(result)
         return None
 
     def responseIsSuccess(self):


### PR DESCRIPTION
Currently https://github.com/plone/plone.app.caching/blob/master/plone/app/caching/operations/ramcache.py#L46
makes `''.join(result)` and then return `None`, so the iterable is consummed, and we get nothing instead.

It is causing the https://dev.plone.org/ticket/12038 bug .

It should actually return a new iterable containing the previous content.

The corresponding integration between plone.app.theming and plone.app.caching is here:
https://github.com/plone/plone.app.theming/tree/ebrehault_fix_12038
(I can move it in plone.app.caching, but I think it makes more sense to let this test on the theming side).
