### PR TITLE
Ruleset registry testing isolation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.2.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix ruleset registry test isolation so that is no longer order dependent.
+  [jone]
 
 
 1.2.1 (2014-04-01)

--- a/plone/app/caching/tests/test_lookup.py
+++ b/plone/app/caching/tests/test_lookup.py
@@ -1,5 +1,5 @@
 import unittest2 as unittest
-from plone.testing.zca import UNIT_TESTING
+from plone.caching.testing import IMPLICIT_RULESET_REGISTRY_UNIT_TESTING
 
 from z3c.caching.registry import RulesetRegistry
 import z3c.caching.registry
@@ -78,11 +78,10 @@ class DummyView(BrowserView):
 
 class TestContentItemLookup(unittest.TestCase):
 
-    layer = UNIT_TESTING
+    layer = IMPLICIT_RULESET_REGISTRY_UNIT_TESTING
 
     def setUp(self):
         provideAdapter(persistentFieldAdapter)
-        provideAdapter(RulesetRegistry)
 
     def test_no_registry(self):
         published = ZopePageTemplate('someView')


### PR DESCRIPTION
Belongs to plone/Products.CMFPlone#223

Fixes a caching ruleset registry testing isolation problem.
It is fixed by using the unit testing layer from `plone.caching` which handles the problem.
The details are described plone/plone.caching/pull/1 

/cc @tisto 
