### PR TITLE
Fix bug in manual purging via controlpanel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Changelog
 - Fixed getObjectDefaultView method to strip off leading / and/or @@.
   [alecghica]
 
+- Fix the portalPath used in the controlpanel for manual purging URL's.
+  This bug resulted in rarely doing all the purging required.
+  [puittenbroek]
+
 
 1.2.2 (2014-10-23)
 ------------------

--- a/plone/app/caching/browser/controlpanel.py
+++ b/plone/app/caching/browser/controlpanel.py
@@ -544,7 +544,7 @@ class Purge(BaseView):
 
         portal_url = getToolByName(self.context, 'portal_url')
         portal = portal_url.getPortalObject()
-        portalPath = '/'.join(portal.getPhysicalPath())
+        portalPath = portal.getPhysicalPath()
 
         proxies = self.purgingSettings.cachingProxies
 


### PR DESCRIPTION
The portalPath's length is used to determine the relativePath from the physicalPath. The physicalPath from the request (line 562) is a list of strings. portalPath was joined as string and thus much longer. Resulting in empty 'relativePath', resulting in not doing all the purges you would expect.

There are no tests for the controlpanel purging, I unfortunally also do not have time to make them :(