### PR TITLE
Show status after synchronous purge if it is an error status.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ Changelog
 
 New:
 
-- *add item here*
+- Show status after synchronous purge if it is an error status.
+  [maurits]
 
 Fixes:
 

--- a/plone/app/caching/browser/controlpanel.py
+++ b/plone/app/caching/browser/controlpanel.py
@@ -530,6 +530,8 @@ class Purge(BaseView):
                     log += " (X-Cache header: " + xcache + ")"
                 if xerror:
                     log += " -- " + xerror
+                if not str(status).startswith('2'):
+                    log += " -- WARNING status " + str(status)
                 self.purgeLog.append(log)
             else:
                 purger.purgeAsync(url)


### PR DESCRIPTION
I had a misconfiguration, where all purge requests were denied by varnish because my ip address was not in the allowed list.  This gave a status 504 on all purge requests, but this was nowhere visible.  The controlpanel only showed 'The following items were purged:' with the list I expected, no errors.