### PR TITLE
Show status after synchronous purge if it is an error status. Branch 1.1.x

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,14 @@ Changelog
 1.1.11 (unreleased)
 ~~~~~~~~~~~~~~~~~~~
 
-- Nothing changed yet.
+New:
+
+- Show status after synchronous purge if it is an error status.
+  [maurits]
+
+Fixes:
+
+- *add item here*
 
 
 1.1.10 (2015-06-09)

--- a/plone/app/caching/browser/controlpanel.py
+++ b/plone/app/caching/browser/controlpanel.py
@@ -535,6 +535,8 @@ class Purge(BaseView):
                     log += " (X-Cache header: " + xcache + ")"
                 if xerror:
                     log += " -- " + xerror
+                if not str(status).startswith('2'):
+                    log += " -- WARNING status " + str(status)
                 self.purgeLog.append(log)
             else:
                 purger.purgeAsync(url)


### PR DESCRIPTION
I had a misconfiguration, where all purge requests were denied by varnish because my ip address was not in the allowed list.  This gave a status 504 on all purge requests, but this was nowhere visible.  The controlpanel only showed 'The following items were purged:' with the list I expected, no errors.

Same as #22 but for Plone 4.3 (branch 1.1.x).