### PR TITLE
Fix tests with ZODB 4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed tests when using ZODB 4.
+  [davisagli]
 
 
 1.2.14 (2016-11-18)

--- a/plone/app/caching/tests/test_lastmodified.py
+++ b/plone/app/caching/tests/test_lastmodified.py
@@ -98,7 +98,7 @@ class TestLastModified(unittest.TestCase):
         mod = datetime.datetime.fromtimestamp(timestamp, tzlocal())
 
         dummy._p_jar = FauxDataManager()
-        dummy._p_serial = repr(ts)
+        dummy._p_serial = ts.raw()
         self.assertEqual(mod, ILastModified(dummy)())
 
     def test_OFSFileLastModified_Image(self):
@@ -115,7 +115,7 @@ class TestLastModified(unittest.TestCase):
         mod = datetime.datetime.fromtimestamp(timestamp, tzlocal())
 
         dummy._p_jar = FauxDataManager()
-        dummy._p_serial = repr(ts)
+        dummy._p_serial = ts.raw()
         self.assertEqual(mod, ILastModified(dummy)())
 
     def test_FSObjectLastModified_FSFile(self):


### PR DESCRIPTION
Fix tests with ZODB 4 by using raw timestamp instead of its repr (the newer ZODB enforces that it must be 8 bytes)