### PR TITLE
Fix title/description of max age in strong caching rule for resources

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,10 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fixed title and description of max age in strong caching rule for resources.
+  They wrongly were the same as for shared max age.
+  Fixes `issue 1989 <https://github.com/plone/Products.CMFPlone/issues/1989>`_.
+  [maurits]
 
 
 1.2.16 (2017-03-23)

--- a/plone/app/caching/profiles/with-caching-proxy/registry.xml
+++ b/plone/app/caching/profiles/with-caching-proxy/registry.xml
@@ -82,7 +82,7 @@
 
   <!-- plone.resource-->
   <record name="plone.app.caching.strongCaching.plone.resource.maxage">
-      <field ref="plone.app.caching.strongCaching.smaxage" />
+      <field ref="plone.app.caching.strongCaching.maxage" />
       <value>86400</value>
   </record>
   <record name="plone.app.caching.strongCaching.plone.resource.lastModified">


### PR DESCRIPTION
They wrongly were the same as for shared max age.
Fixes https://github.com/plone/Products.CMFPlone/issues/1989.