### PR TITLE
Clean up Purge events

### DIFF
--- a/news/37.bugfix
+++ b/news/37.bugfix
@@ -1,0 +1,4 @@
+Only fire 1 Purge() when deleting content, instead of 3 [skurfer]
+Detect and ignore content creation more reliably [skurfer]
+Also purge the parent object when something changes (since the parent probably displays a list that includes the item being changed)
+[skurfer]

--- a/plone/app/caching/purge.py
+++ b/plone/app/caching/purge.py
@@ -24,6 +24,7 @@ from zope.globalrequest import getRequest
 from zope.interface import implementer
 from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 from zope.lifecycleevent.interfaces import IObjectMovedEvent
+from zope.lifecycleevent.interfaces import IObjectRemovedEvent
 from zope.schema import getFieldsInOrder
 
 import six
@@ -279,6 +280,15 @@ def purgeOnModified(object, event):
 
 @adapter(IContentish, IObjectMovedEvent)
 def purgeOnMovedOrRemoved(object, event):
+    request = getRequest()
+    confirmed_delete = (
+        'delete_confirmation' in request.URL
+        and request.REQUEST_METHOD == 'POST'
+        and 'form.submitted' in request.form
+    )
+    if IObjectRemovedEvent.providedBy(event) and not confirmed_delete:
+        # ignore extra delete events
+        return
     # Don't purge when added
     if event.oldName is not None and event.oldParent is not None:
         if isPurged(object):

--- a/plone/app/caching/purge.py
+++ b/plone/app/caching/purge.py
@@ -295,3 +295,6 @@ def purgeOnMovedOrRemoved(object, event):
         return
     if isPurged(object):
         notify(Purge(object))
+    parent = object.getParentNode()
+    if parent:
+        notify(Purge(parent))

--- a/plone/app/caching/purge.py
+++ b/plone/app/caching/purge.py
@@ -293,7 +293,7 @@ def purgeOnMovedOrRemoved(object, event):
     # Don't purge when added
     if IObjectAddedEvent.providedBy(event):
         return
-    if isPurged(object):
+    if isPurged(object) and 'portal_factory' not in request.URL:
         notify(Purge(object))
     parent = object.getParentNode()
     if parent:

--- a/plone/app/caching/purge.py
+++ b/plone/app/caching/purge.py
@@ -22,6 +22,7 @@ from zope.component import getUtility
 from zope.event import notify
 from zope.globalrequest import getRequest
 from zope.interface import implementer
+from zope.lifecycleevent.interfaces import IObjectAddedEvent
 from zope.lifecycleevent.interfaces import IObjectModifiedEvent
 from zope.lifecycleevent.interfaces import IObjectMovedEvent
 from zope.lifecycleevent.interfaces import IObjectRemovedEvent
@@ -290,6 +291,7 @@ def purgeOnMovedOrRemoved(object, event):
         # ignore extra delete events
         return
     # Don't purge when added
-    if event.oldName is not None and event.oldParent is not None:
-        if isPurged(object):
-            notify(Purge(object))
+    if IObjectAddedEvent.providedBy(event):
+        return
+    if isPurged(object):
+        notify(Purge(object))

--- a/plone/app/caching/tests/test_purge.py
+++ b/plone/app/caching/tests/test_purge.py
@@ -30,6 +30,7 @@ from zope.component import provideHandler
 from zope.component import provideUtility
 from zope.component.event import objectEventNotify
 from zope.event import notify
+from zope.globalrequest import getRequest
 from zope.globalrequest import setRequest
 from zope.interface import implementer
 from zope.lifecycleevent import ObjectAddedEvent
@@ -65,7 +66,9 @@ class Handler(object):
 
 
 class FauxRequest(dict):
-    pass
+    REQUEST_METHOD = 'POST'
+    URL = 'http://nohost/test'
+    form = ('form.submitted',)
 
 
 @implementer(IContentish)
@@ -87,6 +90,9 @@ class FauxNonContent(Explicit):
 
     def getPhysicalPath(self):
         return ('', )
+
+    def getParentNode(self):
+        return FauxNonContent('folder')
 
 
 @implementer(IBrowserDefault)
@@ -153,7 +159,7 @@ class TestPurgeRedispatch(unittest.TestCase):
         notify(ObjectMovedEvent(context, FauxContent(), 'old',
                                 context.__parent__, 'new'))
 
-        self.assertEqual(1, len(self.handler.invocations))
+        self.assertEqual(2, len(self.handler.invocations))
         self.assertEqual(context, self.handler.invocations[0].object)
 
     def test_renamed(self):
@@ -163,15 +169,17 @@ class TestPurgeRedispatch(unittest.TestCase):
                                 context.__parent__, 'old',
                                 context.__parent__, 'new'))
 
-        self.assertEqual(1, len(self.handler.invocations))
+        self.assertEqual(2, len(self.handler.invocations))
         self.assertEqual(context, self.handler.invocations[0].object)
 
     def test_removed(self):
         context = FauxContent('new').__of__(FauxContent())
+        request = getRequest()
+        request.URL = 'http://nohost/delete_confirmation'
 
         notify(ObjectRemovedEvent(context, context.__parent__, 'new'))
 
-        self.assertEqual(1, len(self.handler.invocations))
+        self.assertEqual(2, len(self.handler.invocations))
         self.assertEqual(context, self.handler.invocations[0].object)
 
 


### PR DESCRIPTION
We’ve been working on the new `collective.cloudfront` add-on. Since Amazon charges for API calls, it’s become more important to only send `Purge` notifications at the correct times. This is an attempt to fire the events more accurately.

* Only fire 1 `Purge()` when deleting content, instead of 3
* Detect and ignore content creation more reliably
* Also purge the parent object when something changes (since the parent probably displays a list that includes the item being changed)