### PR TITLE
Legacy resource registries made optional

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,12 @@ Bug fixes:
 - Warn after save if caching was disabled while purging is still enabled.
   [jensens]
 
+Clean-up
+
+- Legacy code clean-up
+Old type resource registry Products.ResourceRegistries made optional
+[ksuess]
+
 
 1.2.22 (2018-09-23)
 -------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ Bug fixes:
 Clean-up
 
 - Legacy code clean-up
-Old type resource registry Products.ResourceRegistries made optional
+Handling of legacy resource registries Products.ResourceRegistries removed
 [ksuess]
 
 

--- a/docs/caching-proxies.rst
+++ b/docs/caching-proxies.rst
@@ -22,12 +22,7 @@ returned to a user, because the cache has not been updated since the item
 was modified. There are three general strategies for dealing with this:
 
 * Since resources are cached in the proxy based on their URL, you can
-  "invalidate" the cached copy by changing an item's URL when it is updated.
-  This is the approach taken by Plone's ResourceRegistries (``portal_css``,
-  ``portal_javascript`` & co): in production mode, the links that are inserted
-  into Plone's content pages for resource managed by ResourceRegistries
-  contain a time-based token, which changes when the ResourceRegistries
-  are updated. This approach has the benefit of also being able to
+  "invalidate" the cached copy by changing an item's URL when it is updated. This approach has the benefit of also being able to
   "invalidate" content stored in a user's browser cache.
 
 * All caching proxies support setting timeouts. This means that content may
@@ -90,8 +85,7 @@ The default purge paths include:
   ``Image`` types.
 
 Files and images created (or customised) in the ZMI are purged automatically
-when modified. Files managed through the ResourceRegistries do not need
-purging, since they have "stable" URLs. To purge Plone content when modified
+when modified. To purge Plone content when modified
 (or removed), you must select the content types in the control panel. By
 default, only the ``File`` and ``Image`` types are purged.
 

--- a/docs/etags.rst
+++ b/docs/etags.rst
@@ -42,11 +42,6 @@ The ETag names tokens supported by default are:
 * skin
     The name of the current skin (theme)
 
-* resourceRegistries
-    A timestamp indicating the most recent last-modified date for all three
-    Resource Registries. This is useful for avoiding requests for expired
-    resources from cached pages.
-
 It is possible to provide additional tokens by registering an ``IETagValue``
 adapter. This should be a named adapter on the published object (typically a
 view, file resource or Zope page template object) and request, with a unique

--- a/news/45.breaking
+++ b/news/45.breaking
@@ -1,0 +1,1 @@
+Removed legacy resource registries [ksuess]

--- a/plone/app/caching/caching.zcml
+++ b/plone/app/caching/caching.zcml
@@ -100,13 +100,6 @@
     <!-- Zope resources (including those in resource directories) -->
     <cache:ruleset ruleset="plone.resource" for="zope.browserresource.interfaces.IResource" />
 
-    <!-- Resources cooked in ResourceRegistries -->
-    <configure zcml:condition="installed Products.ResourceRegistries">
-
-        <cache:ruleset ruleset="plone.stableResource" for="Products.ResourceRegistries.interfaces.ICookedFile" />
-
-    </configure>
-
     <!-- Standard Plone (non-blob) file and image content objects -->
     <configure zcml:condition="installed Products.ATContentTypes">
 

--- a/plone/app/caching/configure.zcml
+++ b/plone/app/caching/configure.zcml
@@ -61,7 +61,5 @@
     <adapter factory=".lastmodified.CatalogableDublinCoreLastModified" />
     <adapter factory=".lastmodified.DCTimesLastModified" />
     <adapter factory=".lastmodified.ResourceLastModified" />
-    <adapter zcml:condition="installed some.package"
-             factory=".lastmodified.CookedFileLastModified" />
 
 </configure>

--- a/plone/app/caching/configure.zcml
+++ b/plone/app/caching/configure.zcml
@@ -61,6 +61,7 @@
     <adapter factory=".lastmodified.CatalogableDublinCoreLastModified" />
     <adapter factory=".lastmodified.DCTimesLastModified" />
     <adapter factory=".lastmodified.ResourceLastModified" />
-    <adapter factory=".lastmodified.CookedFileLastModified" />
+    <adapter zcml:condition="installed some.package"
+             factory=".lastmodified.CookedFileLastModified" />
 
 </configure>

--- a/plone/app/caching/lastmodified.py
+++ b/plone/app/caching/lastmodified.py
@@ -14,13 +14,6 @@ from zope.interface import implementer
 from zope.interface import Interface
 from zope.pagetemplate.interfaces import IPageTemplate
 
-# BBB resource registry of old type
-try:
-    from Products.ResourceRegistries.interfaces import ICookedFile
-    from Products.ResourceRegistries.interfaces import IResourceRegistry
-    HAVE_RESOURCE_REGISTRIES = True
-except ImportError:
-    HAVE_RESOURCE_REGISTRIES = False
 
 try:
     from zope.dublincore.interfaces import IDCTimes
@@ -158,27 +151,3 @@ class ResourceLastModified(object):
         lmt = getattr(self.context.context, 'lmt', None)
         if lmt is not None:
             return datetime.fromtimestamp(lmt, tzlocal())
-
-
-if HAVE_RESOURCE_REGISTRIES:
-
-    @implementer(ILastModified)
-    @adapter(ICookedFile)
-    class CookedFileLastModified(object):
-        """ILastModified for Resource Registry `cooked` files
-        """
-
-        def __init__(self, context):
-            self.context = context
-
-        def __call__(self):
-            registry = getContext(self.context, IResourceRegistry)
-            if (
-                registry is None or
-                registry.getDebugMode() or
-                not registry.isCacheable(self.context.__name__)
-            ):
-                return None
-            mtime = getattr(registry.aq_base, '_p_mtime', None)
-            if mtime is not None and mtime > 0:
-                return datetime.fromtimestamp(mtime, tzlocal())

--- a/plone/app/caching/lastmodified.py
+++ b/plone/app/caching/lastmodified.py
@@ -14,7 +14,7 @@ from zope.interface import implementer
 from zope.interface import Interface
 from zope.pagetemplate.interfaces import IPageTemplate
 
-
+# BBB resource registry of old type
 try:
     from Products.ResourceRegistries.interfaces import ICookedFile
     from Products.ResourceRegistries.interfaces import IResourceRegistry

--- a/plone/app/caching/operations/configure.zcml
+++ b/plone/app/caching/operations/configure.zcml
@@ -26,13 +26,6 @@
     <utility component=".default.BaseCaching"           name="plone.app.caching.baseCaching" />
     -->
 
-    <!-- Special handling for content in Plone's ResourceRegistries, if installed -->
-    <adapter
-        zcml:condition="installed Products.ResourceRegistries"
-        factory=".default.ResourceRegistriesCaching"
-        name="plone.app.caching.strongCaching"
-        />
-
     <!-- RAM cache storage: a transformation at the very end of the chain -->
     <adapter factory=".ramcache.Store"                  name="plone.app.caching.operations.ramcache" />
 

--- a/plone/app/caching/operations/configure.zcml
+++ b/plone/app/caching/operations/configure.zcml
@@ -45,7 +45,6 @@
     <adapter factory=".etags.CatalogCounter"            name="catalogCounter" />
     <adapter factory=".etags.ObjectLocked"              name="locked" />
     <adapter factory=".etags.Skin"                      name="skin" />
-    <adapter factory=".etags.ResourceRegistries"        name="resourceRegistries" />
     <adapter factory=".etags.AnonymousOrRandom"         name="anonymousOrRandom" />
     <adapter factory=".etags.CopyCookie"                name="copy" />
 

--- a/plone/app/caching/operations/default.py
+++ b/plone/app/caching/operations/default.py
@@ -26,14 +26,6 @@ import random
 import time
 
 
-try:
-    from Products.ResourceRegistries.interfaces import ICookedFile
-    from Products.ResourceRegistries.interfaces import IResourceRegistry
-    HAVE_RESOURCE_REGISTRIES = True
-except ImportError:
-    HAVE_RESOURCE_REGISTRIES = False
-
-
 @implementer(ICachingOperation)
 @provider(ICachingOperationType)
 @adapter(Interface, Interface)
@@ -297,35 +289,6 @@ class StrongCaching(BaseCaching):
     maxage = 86400
     smaxage = etags = vary = None
     lastModified = ramCache = anonOnly = False
-
-
-if HAVE_RESOURCE_REGISTRIES:
-
-    @adapter(ICookedFile, IHTTPRequest)
-    class ResourceRegistriesCaching(StrongCaching):
-        """Override for StrongCaching which checks ResourceRegistries
-        cacheability
-        """
-
-        def interceptResponse(self, rulename, response):
-            return super(
-                ResourceRegistriesCaching,
-                self,
-            ).interceptResponse(rulename, response, class_=StrongCaching)
-
-        def modifyResponse(self, rulename, response):
-            registry = getContext(self.published, IResourceRegistry)
-
-            if registry is not None:
-                if (
-                    registry.getDebugMode() or
-                    not registry.isCacheable(self.published.__name__)
-                ):
-                    doNotCache(self.published, self.request, response)
-                    return
-
-            super(ResourceRegistriesCaching, self).modifyResponse(
-                rulename, response, class_=StrongCaching)
 
 
 @implementer(ICachingOperation)

--- a/plone/app/caching/operations/etags.py
+++ b/plone/app/caching/operations/etags.py
@@ -184,38 +184,6 @@ class Skin(object):
 
 @implementer(IETagValue)
 @adapter(Interface, Interface)
-class ResourceRegistries(object):
-    """The ``resourceRegistries`` etag component, returning the most recent
-    last modified timestamp from all three Resource Registries.  This is
-    useful for avoiding requests for expired resources from cached pages.
-    """
-
-    def __init__(self, published, request):
-        self.published = published
-        self.request = request
-
-    def __call__(self):
-        context = getContext(self.published)
-
-        registries = []
-        registries.append(getToolByName(context, 'portal_css', None))
-        registries.append(getToolByName(context, 'portal_javascripts', None))
-        registries.append(getToolByName(context, 'portal_kss', None))
-
-        mtimes = []
-        now = time.time()
-        for registry in registries:
-            mtime = now
-            if registry is not None:
-                mtime = getattr(registry.aq_base, '_p_mtime', now)
-                mtimes.append(mtime)
-
-        mtimes.sort()
-        return str(mtimes[-1])
-
-
-@implementer(IETagValue)
-@adapter(Interface, Interface)
 class AnonymousOrRandom(object):
     """The ``anonymousOrRandom`` etag component. This is normally added
     implicitly by the ``anonOnly`` setting. It will return None for anonymous

--- a/plone/app/caching/profiles/with-caching-proxy-splitviews/registry.xml
+++ b/plone/app/caching/profiles/with-caching-proxy-splitviews/registry.xml
@@ -21,7 +21,6 @@
           <element>userLanguage</element>
           <element>skin</element>
           <element>locked</element>
-          <element>resourceRegistries</element>
       </value>
   </record>
   <record name="plone.app.caching.moderateCaching.plone.content.itemView.ramCache">
@@ -49,7 +48,6 @@
           <element>skin</element>
           <element>locked</element>
           <element>copy</element>
-          <element>resourceRegistries</element>
       </value>
   </record>
   <record name="plone.app.caching.moderateCaching.plone.content.folderView.ramCache">

--- a/plone/app/caching/profiles/with-caching-proxy/registry.xml
+++ b/plone/app/caching/profiles/with-caching-proxy/registry.xml
@@ -21,7 +21,6 @@
           <element>userLanguage</element>
           <element>skin</element>
           <element>locked</element>
-          <element>resourceRegistries</element>
       </value>
   </record>
   <record name="plone.app.caching.weakCaching.plone.content.itemView.ramCache">
@@ -40,7 +39,6 @@
           <element>skin</element>
           <element>locked</element>
           <element>copy</element>
-          <element>resourceRegistries</element>
       </value>
   </record>
   <record name="plone.app.caching.weakCaching.plone.content.folderView.ramCache">

--- a/plone/app/caching/profiles/without-caching-proxy/registry.xml
+++ b/plone/app/caching/profiles/without-caching-proxy/registry.xml
@@ -21,7 +21,6 @@
           <element>userLanguage</element>
           <element>skin</element>
           <element>locked</element>
-          <element>resourceRegistries</element>
       </value>
   </record>
   <record name="plone.app.caching.weakCaching.plone.content.itemView.ramCache">
@@ -40,7 +39,6 @@
           <element>skin</element>
           <element>locked</element>
           <element>copy</element>
-          <element>resourceRegistries</element>
       </value>
   </record>
   <record name="plone.app.caching.weakCaching.plone.content.folderView.ramCache">

--- a/plone/app/caching/tests/test_profile_with_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_with_caching_proxy.py
@@ -147,7 +147,7 @@ class TestProfileWithCaching(unittest.TestCase):
         # This should use cacheInBrowser
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
-        self.assertEqual('"|test_user_1_|%d|en|%s|0|0' % (catalog.getCounter(
+        self.assertEqual('"|test_user_1_|%d|en|%s|0' % (catalog.getCounter(
         ), skins_tool.default_skin), _normalize_etag(browser.headers['ETag']))
         self.assertGreater(now, dateutil.parser.parse(
             browser.headers['Expires']))
@@ -162,7 +162,7 @@ class TestProfileWithCaching(unittest.TestCase):
                          browser.headers['X-Cache-Operation'])
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
-        self.assertEqual('"|test_user_1_|%d|en|%s|0|1' % (catalog.getCounter(
+        self.assertEqual('"|test_user_1_|%d|en|%s|0' % (catalog.getCounter(
         ), skins_tool.default_skin), _normalize_etag(browser.headers['ETag']))
 
         # Request the authenticated page
@@ -181,7 +181,7 @@ class TestProfileWithCaching(unittest.TestCase):
         # This should use cacheInBrowser
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
-        self.assertEqual('"|test_user_1_|%d|en|%s|0' % (catalog.getCounter(
+        self.assertEqual('"|test_user_1_|%d|en|%s' % (catalog.getCounter(
         ), skins_tool.default_skin), _normalize_etag(browser.headers['ETag']))
         self.assertGreater(now, dateutil.parser.parse(
             browser.headers['Expires']))
@@ -227,7 +227,7 @@ class TestProfileWithCaching(unittest.TestCase):
         # This should use cacheInBrowser
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
-        self.assertEqual('"||%d|en|%s|0|0' % (catalog.getCounter(
+        self.assertEqual('"||%d|en|%s|0' % (catalog.getCounter(
         ), skins_tool.default_skin), _normalize_etag(browser.headers['ETag']))
         self.assertGreater(now, dateutil.parser.parse(
             browser.headers['Expires']))
@@ -244,7 +244,7 @@ class TestProfileWithCaching(unittest.TestCase):
         # This should use cacheInBrowser
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
-        self.assertEqual('"||%d|en|%s|0' % (catalog.getCounter(
+        self.assertEqual('"||%d|en|%s' % (catalog.getCounter(
         ), skins_tool.default_skin), _normalize_etag(browser.headers['ETag']))
         self.assertGreater(now, dateutil.parser.parse(
             browser.headers['Expires']))
@@ -264,7 +264,7 @@ class TestProfileWithCaching(unittest.TestCase):
         self.assertIn(testText, browser.contents)
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
-        self.assertEqual('"||%d|en|%s|0' % (catalog.getCounter(
+        self.assertEqual('"||%d|en|%s' % (catalog.getCounter(
         ), skins_tool.default_skin), _normalize_etag(browser.headers['ETag']))
         self.assertGreater(now, dateutil.parser.parse(
             browser.headers['Expires']))

--- a/plone/app/caching/tests/test_profile_without_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_without_caching_proxy.py
@@ -62,10 +62,6 @@ class TestProfileWithoutCaching(unittest.TestCase):
         self.app = self.layer['app']
         self.portal = self.layer['portal']
 
-        test_css = FSFile('test.css', os.path.join(
-            os.path.dirname(__file__), 'test.css'))
-        self.portal.portal_skins.custom._setOb('test.css', test_css)
-
         setRequest(self.portal.REQUEST)
 
         applyProfile(self.portal, 'plone.app.caching:without-caching-proxy')
@@ -124,7 +120,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         import transaction
         transaction.commit()
 
-        # Request the quthenticated folder
+        # Request the authenticated folder
         now = stable_now()
         browser = Browser(self.app)
         browser.addHeader(

--- a/plone/app/caching/tests/test_profile_without_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_without_caching_proxy.py
@@ -135,7 +135,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         # This should use cacheInBrowser
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
-        tag = '"|test_user_1_|{0}|en|{1}|0|0'.format(
+        tag = '"|test_user_1_|{0}|en|{1}|0'.format(
             catalog.getCounter(),
             default_skin,
         )
@@ -153,7 +153,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
                          browser.headers['X-Cache-Operation'])
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
-        tag = '"|test_user_1_|{0}|en|{1}|0|1'.format(
+        tag = '"|test_user_1_|{0}|en|{1}|0'.format(
             catalog.getCounter(),
             default_skin,
         )
@@ -175,7 +175,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         # This should use cacheInBrowser
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
-        tag = '"|test_user_1_|{0}|en|{1}|0'.format(
+        tag = '"|test_user_1_|{0}|en|{1}'.format(
             catalog.getCounter(),
             default_skin,
         )
@@ -223,7 +223,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         # This should use cacheInBrowser
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
-        tag = '"||{0}|en|{1}|0|0'.format(catalog.getCounter(), default_skin)
+        tag = '"||{0}|en|{1}|0'.format(catalog.getCounter(), default_skin)
         self.assertEqual(tag, _normalize_etag(browser.headers['ETag']))
         self.assertGreater(now, dateutil.parser.parse(
             browser.headers['Expires']))
@@ -240,7 +240,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         # This should use cacheInBrowser
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
-        tag = '"||{0}|en|{1}|0'.format(catalog.getCounter(), default_skin)
+        tag = '"||{0}|en|{1}'.format(catalog.getCounter(), default_skin)
         self.assertEqual(tag, _normalize_etag(browser.headers['ETag']))
         self.assertGreater(now, dateutil.parser.parse(
             browser.headers['Expires']))
@@ -260,7 +260,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         self.assertIn(testText, browser.contents)
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
-        tag = '"||{0}|en|{1}|0'.format(catalog.getCounter(), default_skin)
+        tag = '"||{0}|en|{1}'.format(catalog.getCounter(), default_skin)
         self.assertEqual(tag, _normalize_etag(browser.headers['ETag']))
         self.assertGreater(now, dateutil.parser.parse(
             browser.headers['Expires']))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = '1.2.24.dev0'
+version = '2.0.dev0'
 
 setup(
     name='plone.app.caching',
@@ -14,8 +14,6 @@ setup(
     classifiers=[
         'Environment :: Web Environment',
         'Framework :: Plone',
-        'Framework :: Plone :: 5.0',
-        'Framework :: Plone :: 5.1',
         'Framework :: Plone :: 5.2',
         'Framework :: Zope2',
         'License :: OSI Approved :: GNU General Public License v2 (GPLv2)',


### PR DESCRIPTION
Products.ResourceRegistries (portal_css, portal_javascript) is replaced by new type Resource Registries https://docs.plone.org/adapt-and-extend/config/resource-registries.html