### PR TITLE
Purging image scales of behavior fields

### DIFF
--- a/news/55.bugfix
+++ b/news/55.bugfix
@@ -1,0 +1,2 @@
+Purging image scales of behavior fields, e.g. lead image
+[ksuess]

--- a/plone/app/caching/purge.py
+++ b/plone/app/caching/purge.py
@@ -192,7 +192,7 @@ class ScalesPurgePaths(object):
             assignable = IBehaviorAssignable(self.context, None)
             for behavior in assignable.enumerateBehaviors():
                 if behavior.marker:
-                    new_fields = getFieldsInOrder(behavior.marker)
+                    new_fields = getFieldsInOrder(behavior.interface)
                     if len(new_fields) > 0:
                         fields = fields + new_fields
 

--- a/plone/app/caching/purge.py
+++ b/plone/app/caching/purge.py
@@ -191,10 +191,9 @@ class ScalesPurgePaths(object):
             fields = getFieldsInOrder(schema)
             assignable = IBehaviorAssignable(self.context, None)
             for behavior in assignable.enumerateBehaviors():
-                if behavior.marker:
-                    new_fields = getFieldsInOrder(behavior.interface)
-                    if len(new_fields) > 0:
-                        fields = fields + new_fields
+                new_fields = getFieldsInOrder(behavior.interface)
+                if len(new_fields) > 0:
+                    fields = fields + new_fields
 
             obj_fields = []
             for key, value in fields:


### PR DESCRIPTION
e.g. lead image

Until now image scales of lead image behavior are not purged.
#39 nearly does add the scales paths to the set to be purged.

Fixes https://github.com/plone/plone.app.caching/issues/54

BTW enabling a behavior programmatically needs an unexpected effort: a custom IBehaviorAssignable adapter.