### PR TITLE
Fixed invalid escape sequences.

### DIFF
--- a/news/3130.bugfix
+++ b/news/3130.bugfix
@@ -1,0 +1,2 @@
+Fixed invalid escape sequences.
+[maurits]

--- a/plone/app/caching/operations/utils.py
+++ b/plone/app/caching/operations/utils.py
@@ -33,11 +33,9 @@ _marker = object()
 logger = logging.getLogger('plone.app.caching')
 
 parseETagLock = allocate_lock()
-# etagQuote = re.compile('(\s*\"([^\"]*)\"\s*,{0,1})')
-# etagNoQuote = re.compile('(\s*([^,]*)\s*,{0,1})')
 
-etagQuote = re.compile('(\s*(W\/)?\"([^\"]*)\"\s*,?)')
-etagNoQuote = re.compile('(\s*(W\/)?([^,]*)\s*,?)')
+etagQuote = re.compile(r'(\s*(W\/)?"([^"]*)"\s*,?)')
+etagNoQuote = re.compile(r'(\s*(W\/)?([^,]*)\s*,?)')
 
 #
 # Operation helpers, used in the implementations of interceptResponse() and


### PR DESCRIPTION
Notes for people reviewing PRs that fix invalid escape sequences, or who want to fix some themselves in core or other code:

- The invalid escape sequences are usually in a `re.compile` or `re.match`, but it does not need to have anything to do with regular expressions.
- Sometimes you can simply put an `r` in front of the string and it is fine.
- Sometimes the `r` in front leads to a different meaning.
- It can very well be that the original code is bad and not really working as intended.
- It can also very well be that the original code is good and working fine. Still: in a future Python version, the current deprecation warning may turn into a SyntaxError instead.

It is a good idea to use Python itself to check whether a normal string and a raw string are the same.
For example in the `etagNoQuote` in here you can see that there is no difference. Using a Python prompt:

```
>>> '(\s*(W\/)?([^,]*)\s*,?)' == r'(\s*(W\/)?([^,]*)\s*,?)'
True
```

or a simpler example:

```
>>> 'a' == r'a'
True
```

But for the `etagQuote` the `r` *does* make a difference, so you really need to edit the raw string:

```
>>> '(\s*(W\/)?\"([^\"]*)\"\s*,?)' == r'(\s*(W\/)?\"([^\"]*)\"\s*,?)'
False
>>> '(\s*(W\/)?\"([^\"]*)\"\s*,?)'
'(\\s*(W\\/)?"([^"]*)"\\s*,?)'
>>> r'(\s*(W\/)?\"([^\"]*)\"\s*,?)'
'(\\s*(W\\/)?\\"([^\\"]*)\\"\\s*,?)'
>>> '(\s*(W\/)?\"([^\"]*)\"\s*,?)' == r'(\s*(W\/)?"([^"]*)"\s*,?)'
True
```

or a simpler example:

```
>>> '\a' == r'\a'
False
>>> '\a'
'\x07'
>>> r'\a'
'\\a'
```

I am not really sure whether it matters if you do these tests with Python 2 or 3. In the above cases, the outcome is the same.

I don't always go out of my way to check that a change is good. If the tests still pass, and the `DeprecationWarning: invalid escape sequence` is gone, then it is probably okay.
