### PR TITLE
Restore and modernize resourceRegistries ETag.

### DIFF
--- a/docs/caching-proxies.rst
+++ b/docs/caching-proxies.rst
@@ -22,7 +22,13 @@ returned to a user, because the cache has not been updated since the item
 was modified. There are three general strategies for dealing with this:
 
 * Since resources are cached in the proxy based on their URL, you can
-  "invalidate" the cached copy by changing an item's URL when it is updated. This approach has the benefit of also being able to
+  "invalidate" the cached copy by changing an item's URL when it is updated.
+  This is the approach taken by Plone's ResourceRegistries:
+  in production mode, the links that are inserted
+  into Plone's content pages for resource managed by ResourceRegistries
+  contain a time-based token, which changes when the ResourceRegistries
+  are updated, more specifically: when the resource bundles are combined.
+  This approach has the benefit of also being able to
   "invalidate" content stored in a user's browser cache.
 
 * All caching proxies support setting timeouts. This means that content may
@@ -85,7 +91,8 @@ The default purge paths include:
   ``Image`` types.
 
 Files and images created (or customised) in the ZMI are purged automatically
-when modified. To purge Plone content when modified
+when modified. Files managed through the ResourceRegistries do not need
+purging, since they have "stable" URLs. To purge Plone content when modified
 (or removed), you must select the content types in the control panel. By
 default, only the ``File`` and ``Image`` types are purged.
 

--- a/docs/etags.rst
+++ b/docs/etags.rst
@@ -42,6 +42,11 @@ The ETag names tokens supported by default are:
 * skin
     The name of the current skin (theme)
 
+* resourceRegistries
+    A timestamp indicating the last-modified timestamp for the
+    Resource Registries. This is useful for avoiding requests for expired
+    resources from cached pages.
+
 It is possible to provide additional tokens by registering an ``IETagValue``
 adapter. This should be a named adapter on the published object (typically a
 view, file resource or Zope page template object) and request, with a unique

--- a/news/61.feature
+++ b/news/61.feature
@@ -1,0 +1,3 @@
+Restored ``resourceRegistries`` ETag, but now for Plone 5 resource registries.
+Fixes warning "Could not find value adapter for ETag component resourceRegistries".
+[maurits]

--- a/plone/app/caching/lastmodified.py
+++ b/plone/app/caching/lastmodified.py
@@ -2,7 +2,6 @@ from Acquisition import aq_base
 from datetime import datetime
 from dateutil.tz import tzlocal
 from OFS.Image import File
-from plone.app.caching.operations.utils import getContext
 from Products.CMFCore.FSObject import FSObject
 from Products.CMFCore.FSPageTemplate import FSPageTemplate
 from Products.CMFCore.interfaces import ICatalogableDublinCore

--- a/plone/app/caching/operations/configure.zcml
+++ b/plone/app/caching/operations/configure.zcml
@@ -41,6 +41,7 @@
     <adapter factory=".etags.CatalogCounter"            name="catalogCounter" />
     <adapter factory=".etags.ObjectLocked"              name="locked" />
     <adapter factory=".etags.Skin"                      name="skin" />
+    <adapter factory=".etags.ResourceRegistries"        name="resourceRegistries" />
     <adapter factory=".etags.AnonymousOrRandom"         name="anonymousOrRandom" />
     <adapter factory=".etags.CopyCookie"                name="copy" />
 

--- a/plone/app/caching/operations/etags.py
+++ b/plone/app/caching/operations/etags.py
@@ -5,6 +5,8 @@ from plone.app.caching.operations.utils import getLastModifiedAnnotation
 from Products.CMFCore.interfaces import IMembershipTool
 from Products.CMFCore.utils import getToolByName
 from Products.CMFCore.interfaces import ICatalogTool
+from Products.CMFPlone.resources.browser.combine import get_override_directory
+from Products.CMFPlone.resources.browser.combine import PRODUCTION_RESOURCE_DIRECTORY
 from zope.component import adapter
 from zope.component import queryMultiAdapter
 from zope.component import queryUtility
@@ -219,3 +221,35 @@ class CopyCookie:
 
     def __call__(self):
         return "1" if self.request.get("__cp") else "0"
+
+
+@implementer(IETagValue)
+@adapter(Interface, Interface)
+class ResourceRegistries(object):
+    """The ``resourceRegistries`` etag component, returning a timestamp.
+
+    This is the last modified timestamp from the Plone 5+ Resource Registries.
+    This is useful for avoiding requests for expired resources from cached pages.
+    """
+
+    def __init__(self, published, request):
+        self.published = published
+        self.request = request
+
+    def __call__(self):
+        context = getContext(self.published)
+        container = get_override_directory(context)
+        if PRODUCTION_RESOURCE_DIRECTORY not in container:
+            return ''
+        production_folder = container[PRODUCTION_RESOURCE_DIRECTORY]
+        filename = 'timestamp.txt'
+        if filename not in production_folder:
+            return ''
+        timestamp = production_folder.readFile(filename)
+        if not timestamp:
+            return ''
+        # timestamp is in bytes, and we must return a string.
+        # On Python 2 this is the same, but not on Python 3.
+        if not isinstance(timestamp, str):
+            timestamp = timestamp.decode("utf-8")
+        return timestamp

--- a/plone/app/caching/profiles/with-caching-proxy-splitviews/registry.xml
+++ b/plone/app/caching/profiles/with-caching-proxy-splitviews/registry.xml
@@ -21,6 +21,7 @@
           <element>userLanguage</element>
           <element>skin</element>
           <element>locked</element>
+          <element>resourceRegistries</element>
       </value>
   </record>
   <record name="plone.app.caching.moderateCaching.plone.content.itemView.ramCache">
@@ -48,6 +49,7 @@
           <element>skin</element>
           <element>locked</element>
           <element>copy</element>
+          <element>resourceRegistries</element>
       </value>
   </record>
   <record name="plone.app.caching.moderateCaching.plone.content.folderView.ramCache">

--- a/plone/app/caching/profiles/with-caching-proxy/registry.xml
+++ b/plone/app/caching/profiles/with-caching-proxy/registry.xml
@@ -22,6 +22,7 @@
           <element>userLanguage</element>
           <element>skin</element>
           <element>locked</element>
+          <element>resourceRegistries</element>
       </value>
   </record>
   <record name="plone.app.caching.weakCaching.plone.content.itemView.ramCache">
@@ -40,6 +41,7 @@
           <element>skin</element>
           <element>locked</element>
           <element>copy</element>
+          <element>resourceRegistries</element>
       </value>
   </record>
   <record name="plone.app.caching.weakCaching.plone.content.folderView.ramCache">

--- a/plone/app/caching/profiles/without-caching-proxy/registry.xml
+++ b/plone/app/caching/profiles/without-caching-proxy/registry.xml
@@ -22,6 +22,7 @@
           <element>userLanguage</element>
           <element>skin</element>
           <element>locked</element>
+          <element>resourceRegistries</element>
       </value>
   </record>
   <record name="plone.app.caching.weakCaching.plone.content.itemView.ramCache">
@@ -40,6 +41,7 @@
           <element>skin</element>
           <element>locked</element>
           <element>copy</element>
+          <element>resourceRegistries</element>
       </value>
   </record>
   <record name="plone.app.caching.weakCaching.plone.content.folderView.ramCache">

--- a/plone/app/caching/tests/test_integration.py
+++ b/plone/app/caching/tests/test_integration.py
@@ -119,27 +119,29 @@ class TestOperations(unittest.TestCase):
         self.portal.portal_workflow.doActionFor(self.portal["f1"]["d1"], "publish")
 
         # Content image
-        self.portal["f1"].invokeFactory("Image", "i1")
-        self.portal["f1"]["i1"].title = "Image one"
-        self.portal["f1"]["i1"].description = "Image one description"
-        with open(TEST_IMAGE, "rb") as ti:
-            self.portal["f1"]["i1"].image = NamedImage(ti, "image/gif", "test.gif")
-        self.portal["f1"]["i1"].reindexObject()
+        self.portal['f1'].invokeFactory('Image', 'i1')
+        self.portal['f1']['i1'].title = u'Image one'
+        self.portal['f1']['i1'].description = u'Image one description'
+        with open(TEST_IMAGE, 'rb') as myfile:
+            self.portal['f1']['i1'].image = NamedImage(
+                myfile, 'image/gif', u'test.gif')
+        self.portal['f1']['i1'].reindexObject()
 
         # Content file
-        self.portal["f1"].invokeFactory("File", "f1")
-        self.portal["f1"]["f1"].title = "File one"
-        self.portal["f1"]["f1"].description = "File one description"
-        with open(TEST_FILE, "rb") as tf:
-            self.portal["f1"]["f1"].file = OFS.Image.File("test.gif", "test.gif", tf)
-        self.portal["f1"]["f1"].reindexObject()
+        self.portal['f1'].invokeFactory('File', 'f1')
+        self.portal['f1']['f1'].title = u'File one'
+        self.portal['f1']['f1'].description = u'File one description'
+        with open(TEST_FILE, 'rb') as myfile:
+            self.portal['f1']['f1'].file = OFS.Image.File(
+                'test.gif', 'test.gif', myfile)
+        self.portal['f1']['f1'].reindexObject()
 
         # OFS image (custom folder)
-        with open(TEST_IMAGE, "rb") as ti:
+        with open(TEST_IMAGE, 'rb') as myfile:
             OFS.Image.manage_addImage(
-                self.portal["portal_skins"]["custom"],
-                "test.gif",
-                ti,
+                self.portal['portal_skins']['custom'],
+                'test.gif',
+                myfile,
             )
 
         setRoles(self.portal, TEST_USER_ID, ("Member",))

--- a/plone/app/caching/tests/test_profile_with_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_with_caching_proxy.py
@@ -4,6 +4,7 @@ from plone.app.caching.testing import PLONE_APP_CACHING_FUNCTIONAL_RESTAPI_TESTI
 from plone.app.caching.testing import PLONE_APP_CACHING_FUNCTIONAL_TESTING
 from plone.app.caching.tests.test_utils import normalize_etag
 from plone.app.caching.tests.test_utils import stable_now
+from plone.app.caching.tests.test_utils import test_image
 from plone.app.testing import applyProfile
 from plone.app.testing import setRoles
 from plone.app.testing import SITE_OWNER_NAME
@@ -27,23 +28,7 @@ import datetime
 import dateutil.parser
 import dateutil.tz
 import os
-import pkg_resources
-import transaction
 import unittest
-
-
-TEST_FILE = pkg_resources.resource_filename("plone.app.caching.tests", "test.gif")
-
-
-def test_image():
-    from plone.namedfile.file import NamedBlobImage
-
-    filename = pkg_resources.resource_filename("plone.app.caching.tests", "test.gif")
-    filename = os.path.join(os.path.dirname(__file__), "test.gif")
-    return NamedBlobImage(
-        data=open(filename, "rb").read(),
-        filename=filename,
-    )
 
 
 class TestProfileWithCaching(unittest.TestCase):

--- a/plone/app/caching/tests/test_profile_with_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_with_caching_proxy.py
@@ -28,6 +28,7 @@ import datetime
 import dateutil.parser
 import dateutil.tz
 import os
+import transaction
 import unittest
 
 

--- a/plone/app/caching/tests/test_profile_with_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_with_caching_proxy.py
@@ -148,32 +148,25 @@ class TestProfileWithCaching(unittest.TestCase):
             "plone.app.caching.weakCaching", browser.headers["X-Cache-Operation"]
         )
         # This should use cacheInBrowser
-        self.assertEqual(
-            "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
-        )
-        self.assertEqual(
-            '"|test_user_1_|%d|en|%s|0'
-            % (catalog.getCounter(), skins_tool.default_skin),
-            _normalize_etag(browser.headers["ETag"]),
-        )
-        self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
+        self.assertEqual('max-age=0, must-revalidate, private',
+                         browser.headers['Cache-Control'])
+        self.assertEqual('"|test_user_1_|%d|en|%s|0|0' % (catalog.getCounter(
+        ), skins_tool.default_skin), _normalize_etag(browser.headers['ETag']))
+        self.assertGreater(now, dateutil.parser.parse(
+            browser.headers['Expires']))
 
         # Set the copy/cut cookie and then request the folder view again
         browser.cookies.create("__cp", "xxx")
         browser.open(self.portal["f1"].absolute_url())
         # The response should be the same as before except for the etag
-        self.assertEqual("plone.content.folderView", browser.headers["X-Cache-Rule"])
-        self.assertEqual(
-            "plone.app.caching.weakCaching", browser.headers["X-Cache-Operation"]
-        )
-        self.assertEqual(
-            "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
-        )
-        self.assertEqual(
-            '"|test_user_1_|%d|en|%s|0'
-            % (catalog.getCounter(), skins_tool.default_skin),
-            _normalize_etag(browser.headers["ETag"]),
-        )
+        self.assertEqual('plone.content.folderView',
+                         browser.headers['X-Cache-Rule'])
+        self.assertEqual('plone.app.caching.weakCaching',
+                         browser.headers['X-Cache-Operation'])
+        self.assertEqual('max-age=0, must-revalidate, private',
+                         browser.headers['Cache-Control'])
+        self.assertEqual('"|test_user_1_|%d|en|%s|0|1' % (catalog.getCounter(
+        ), skins_tool.default_skin), _normalize_etag(browser.headers['ETag']))
 
         # Request the authenticated page
         now = stable_now()
@@ -192,14 +185,12 @@ class TestProfileWithCaching(unittest.TestCase):
             "plone.app.caching.weakCaching", browser.headers["X-Cache-Operation"]
         )
         # This should use cacheInBrowser
-        self.assertEqual(
-            "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
-        )
-        self.assertEqual(
-            '"|test_user_1_|%d|en|%s' % (catalog.getCounter(), skins_tool.default_skin),
-            _normalize_etag(browser.headers["ETag"]),
-        )
-        self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
+        self.assertEqual('max-age=0, must-revalidate, private',
+                         browser.headers['Cache-Control'])
+        self.assertEqual('"|test_user_1_|%d|en|%s|0' % (catalog.getCounter(
+        ), skins_tool.default_skin), _normalize_etag(browser.headers['ETag']))
+        self.assertGreater(now, dateutil.parser.parse(
+            browser.headers['Expires']))
 
         # Request the authenticated page again -- to test RAM cache.
         browser = Browser(self.app)
@@ -246,14 +237,12 @@ class TestProfileWithCaching(unittest.TestCase):
             "plone.app.caching.weakCaching", browser.headers["X-Cache-Operation"]
         )
         # This should use cacheInBrowser
-        self.assertEqual(
-            "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
-        )
-        self.assertEqual(
-            '"||%d|en|%s|0' % (catalog.getCounter(), skins_tool.default_skin),
-            _normalize_etag(browser.headers["ETag"]),
-        )
-        self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
+        self.assertEqual('max-age=0, must-revalidate, private',
+                         browser.headers['Cache-Control'])
+        self.assertEqual('"||%d|en|%s|0|0' % (catalog.getCounter(
+        ), skins_tool.default_skin), _normalize_etag(browser.headers['ETag']))
+        self.assertGreater(now, dateutil.parser.parse(
+            browser.headers['Expires']))
 
         # Request the anonymous page
         now = stable_now()
@@ -265,14 +254,12 @@ class TestProfileWithCaching(unittest.TestCase):
         )
         self.assertIn(testText, browser.contents)
         # This should use cacheInBrowser
-        self.assertEqual(
-            "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
-        )
-        self.assertEqual(
-            '"||%d|en|%s' % (catalog.getCounter(), skins_tool.default_skin),
-            _normalize_etag(browser.headers["ETag"]),
-        )
-        self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
+        self.assertEqual('max-age=0, must-revalidate, private',
+                         browser.headers['Cache-Control'])
+        self.assertEqual('"||%d|en|%s|0' % (catalog.getCounter(
+        ), skins_tool.default_skin), _normalize_etag(browser.headers['ETag']))
+        self.assertGreater(now, dateutil.parser.parse(
+            browser.headers['Expires']))
 
         # Request the anonymous page again -- to test RAM cache.
         # Anonymous should be RAM cached
@@ -288,14 +275,12 @@ class TestProfileWithCaching(unittest.TestCase):
             "plone.app.caching.operations.ramcache", browser.headers["X-RAMCache"]
         )
         self.assertIn(testText, browser.contents)
-        self.assertEqual(
-            "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
-        )
-        self.assertEqual(
-            '"||%d|en|%s' % (catalog.getCounter(), skins_tool.default_skin),
-            _normalize_etag(browser.headers["ETag"]),
-        )
-        self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
+        self.assertEqual('max-age=0, must-revalidate, private',
+                         browser.headers['Cache-Control'])
+        self.assertEqual('"||%d|en|%s|0' % (catalog.getCounter(
+        ), skins_tool.default_skin), _normalize_etag(browser.headers['ETag']))
+        self.assertGreater(now, dateutil.parser.parse(
+            browser.headers['Expires']))
 
         # Request the anonymous page again -- with an INM header to test 304.
         etag = browser.headers["ETag"]

--- a/plone/app/caching/tests/test_profile_with_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_with_caching_proxy.py
@@ -2,6 +2,7 @@ from io import BytesIO
 from plone.app.caching.interfaces import IPloneCacheSettings
 from plone.app.caching.testing import PLONE_APP_CACHING_FUNCTIONAL_RESTAPI_TESTING
 from plone.app.caching.testing import PLONE_APP_CACHING_FUNCTIONAL_TESTING
+from plone.app.caching.tests.test_utils import normalize_etag
 from plone.app.caching.tests.test_utils import stable_now
 from plone.app.testing import applyProfile
 from plone.app.testing import setRoles
@@ -43,12 +44,6 @@ def test_image():
         data=open(filename, "rb").read(),
         filename=filename,
     )
-
-
-def _normalize_etag(s):
-    s = s.split("|")
-    s.pop()  # remove time-based component
-    return "|".join(s)
 
 
 class TestProfileWithCaching(unittest.TestCase):
@@ -151,7 +146,7 @@ class TestProfileWithCaching(unittest.TestCase):
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
         self.assertEqual('"|test_user_1_|%d|en|%s|0|0' % (catalog.getCounter(
-        ), skins_tool.default_skin), _normalize_etag(browser.headers['ETag']))
+        ), skins_tool.default_skin), normalize_etag(browser.headers['ETag']))
         self.assertGreater(now, dateutil.parser.parse(
             browser.headers['Expires']))
 
@@ -166,7 +161,7 @@ class TestProfileWithCaching(unittest.TestCase):
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
         self.assertEqual('"|test_user_1_|%d|en|%s|0|1' % (catalog.getCounter(
-        ), skins_tool.default_skin), _normalize_etag(browser.headers['ETag']))
+        ), skins_tool.default_skin), normalize_etag(browser.headers['ETag']))
 
         # Request the authenticated page
         now = stable_now()
@@ -188,7 +183,7 @@ class TestProfileWithCaching(unittest.TestCase):
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
         self.assertEqual('"|test_user_1_|%d|en|%s|0' % (catalog.getCounter(
-        ), skins_tool.default_skin), _normalize_etag(browser.headers['ETag']))
+        ), skins_tool.default_skin), normalize_etag(browser.headers['ETag']))
         self.assertGreater(now, dateutil.parser.parse(
             browser.headers['Expires']))
 
@@ -240,7 +235,7 @@ class TestProfileWithCaching(unittest.TestCase):
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
         self.assertEqual('"||%d|en|%s|0|0' % (catalog.getCounter(
-        ), skins_tool.default_skin), _normalize_etag(browser.headers['ETag']))
+        ), skins_tool.default_skin), normalize_etag(browser.headers['ETag']))
         self.assertGreater(now, dateutil.parser.parse(
             browser.headers['Expires']))
 
@@ -257,7 +252,7 @@ class TestProfileWithCaching(unittest.TestCase):
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
         self.assertEqual('"||%d|en|%s|0' % (catalog.getCounter(
-        ), skins_tool.default_skin), _normalize_etag(browser.headers['ETag']))
+        ), skins_tool.default_skin), normalize_etag(browser.headers['ETag']))
         self.assertGreater(now, dateutil.parser.parse(
             browser.headers['Expires']))
 
@@ -278,7 +273,7 @@ class TestProfileWithCaching(unittest.TestCase):
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
         self.assertEqual('"||%d|en|%s|0' % (catalog.getCounter(
-        ), skins_tool.default_skin), _normalize_etag(browser.headers['ETag']))
+        ), skins_tool.default_skin), normalize_etag(browser.headers['ETag']))
         self.assertGreater(now, dateutil.parser.parse(
             browser.headers['Expires']))
 

--- a/plone/app/caching/tests/test_profile_without_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_without_caching_proxy.py
@@ -15,6 +15,7 @@ from plone.caching.interfaces import ICacheSettings
 from plone.registry.interfaces import IRegistry
 from plone.restapi.testing import RelativeSession
 from plone.testing.z2 import Browser
+from Products.CMFCore.FSFile import FSFile
 from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility
 from zope.globalrequest import setRequest
@@ -22,6 +23,9 @@ from zope.globalrequest import setRequest
 import datetime
 import dateutil.parser
 import dateutil.tz
+import io
+import os
+import transaction
 import unittest
 
 

--- a/plone/app/caching/tests/test_profile_without_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_without_caching_proxy.py
@@ -1,6 +1,7 @@
 from plone.app.caching.interfaces import IPloneCacheSettings
 from plone.app.caching.testing import PLONE_APP_CACHING_FUNCTIONAL_RESTAPI_TESTING
 from plone.app.caching.testing import PLONE_APP_CACHING_FUNCTIONAL_TESTING
+from plone.app.caching.tests.test_utils import normalize_etag
 from plone.app.caching.tests.test_utils import stable_now
 from plone.app.testing import applyProfile
 from plone.app.testing import setRoles
@@ -40,12 +41,6 @@ def test_image():
         data=open(filename, "rb").read(),
         filename=filename,
     )
-
-
-def _normalize_etag(s):
-    s = s.split("|")
-    s.pop()  # remove time-based component
-    return "|".join(s)
 
 
 class TestProfileWithoutCaching(unittest.TestCase):
@@ -138,8 +133,9 @@ class TestProfileWithoutCaching(unittest.TestCase):
             catalog.getCounter(),
             default_skin,
         )
-        self.assertEqual(tag, _normalize_etag(browser.headers["ETag"]))
-        self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
+        self.assertEqual(tag, normalize_etag(browser.headers['ETag']))
+        self.assertGreater(now, dateutil.parser.parse(
+            browser.headers['Expires']))
 
         # Set the copy/cut cookie and then request the folder view again
         browser.cookies.create("__cp", "xxx")
@@ -155,7 +151,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
             catalog.getCounter(),
             default_skin,
         )
-        self.assertEqual(tag, _normalize_etag(browser.headers["ETag"]))
+        self.assertEqual(tag, normalize_etag(browser.headers['ETag']))
 
         # Request the authenticated page
         now = stable_now()
@@ -180,8 +176,9 @@ class TestProfileWithoutCaching(unittest.TestCase):
             catalog.getCounter(),
             default_skin,
         )
-        self.assertEqual(tag, _normalize_etag(browser.headers["ETag"]))
-        self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
+        self.assertEqual(tag, normalize_etag(browser.headers['ETag']))
+        self.assertGreater(now, dateutil.parser.parse(
+            browser.headers['Expires']))
 
         # Request the authenticated page again -- to test RAM cache.
         browser = Browser(self.app)
@@ -230,7 +227,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
         tag = '"||{0}|en|{1}|0|0'.format(catalog.getCounter(), default_skin)
-        self.assertEqual(tag, _normalize_etag(browser.headers['ETag']))
+        self.assertEqual(tag, normalize_etag(browser.headers['ETag']))
         self.assertGreater(now, dateutil.parser.parse(
             browser.headers['Expires']))
 
@@ -247,7 +244,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
         tag = '"||{0}|en|{1}|0'.format(catalog.getCounter(), default_skin)
-        self.assertEqual(tag, _normalize_etag(browser.headers['ETag']))
+        self.assertEqual(tag, normalize_etag(browser.headers['ETag']))
         self.assertGreater(now, dateutil.parser.parse(
             browser.headers['Expires']))
 
@@ -268,7 +265,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         self.assertEqual('max-age=0, must-revalidate, private',
                          browser.headers['Cache-Control'])
         tag = '"||{0}|en|{1}|0'.format(catalog.getCounter(), default_skin)
-        self.assertEqual(tag, _normalize_etag(browser.headers['ETag']))
+        self.assertEqual(tag, normalize_etag(browser.headers['ETag']))
         self.assertGreater(now, dateutil.parser.parse(
             browser.headers['Expires']))
 

--- a/plone/app/caching/tests/test_profile_without_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_without_caching_proxy.py
@@ -14,7 +14,6 @@ from plone.caching.interfaces import ICacheSettings
 from plone.registry.interfaces import IRegistry
 from plone.restapi.testing import RelativeSession
 from plone.testing.z2 import Browser
-from Products.CMFCore.FSFile import FSFile
 from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility
 from zope.globalrequest import setRequest

--- a/plone/app/caching/tests/test_profile_without_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_without_caching_proxy.py
@@ -132,10 +132,9 @@ class TestProfileWithoutCaching(unittest.TestCase):
             "plone.app.caching.weakCaching", browser.headers["X-Cache-Operation"]
         )
         # This should use cacheInBrowser
-        self.assertEqual(
-            "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
-        )
-        tag = '"|test_user_1_|{}|en|{}|0'.format(
+        self.assertEqual('max-age=0, must-revalidate, private',
+                         browser.headers['Cache-Control'])
+        tag = '"|test_user_1_|{0}|en|{1}|0|0'.format(
             catalog.getCounter(),
             default_skin,
         )
@@ -146,14 +145,13 @@ class TestProfileWithoutCaching(unittest.TestCase):
         browser.cookies.create("__cp", "xxx")
         browser.open(self.portal["f1"].absolute_url())
         # The response should be the same as before except for the etag
-        self.assertEqual("plone.content.folderView", browser.headers["X-Cache-Rule"])
-        self.assertEqual(
-            "plone.app.caching.weakCaching", browser.headers["X-Cache-Operation"]
-        )
-        self.assertEqual(
-            "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
-        )
-        tag = '"|test_user_1_|{}|en|{}|0'.format(
+        self.assertEqual('plone.content.folderView',
+                         browser.headers['X-Cache-Rule'])
+        self.assertEqual('plone.app.caching.weakCaching',
+                         browser.headers['X-Cache-Operation'])
+        self.assertEqual('max-age=0, must-revalidate, private',
+                         browser.headers['Cache-Control'])
+        tag = '"|test_user_1_|{0}|en|{1}|0|1'.format(
             catalog.getCounter(),
             default_skin,
         )
@@ -176,10 +174,9 @@ class TestProfileWithoutCaching(unittest.TestCase):
             "plone.app.caching.weakCaching", browser.headers["X-Cache-Operation"]
         )
         # This should use cacheInBrowser
-        self.assertEqual(
-            "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
-        )
-        tag = '"|test_user_1_|{}|en|{}'.format(
+        self.assertEqual('max-age=0, must-revalidate, private',
+                         browser.headers['Cache-Control'])
+        tag = '"|test_user_1_|{0}|en|{1}|0'.format(
             catalog.getCounter(),
             default_skin,
         )
@@ -230,12 +227,12 @@ class TestProfileWithoutCaching(unittest.TestCase):
             "plone.app.caching.weakCaching", browser.headers["X-Cache-Operation"]
         )
         # This should use cacheInBrowser
-        self.assertEqual(
-            "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
-        )
-        tag = f'"||{catalog.getCounter()}|en|{default_skin}|0'
-        self.assertEqual(tag, _normalize_etag(browser.headers["ETag"]))
-        self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
+        self.assertEqual('max-age=0, must-revalidate, private',
+                         browser.headers['Cache-Control'])
+        tag = '"||{0}|en|{1}|0|0'.format(catalog.getCounter(), default_skin)
+        self.assertEqual(tag, _normalize_etag(browser.headers['ETag']))
+        self.assertGreater(now, dateutil.parser.parse(
+            browser.headers['Expires']))
 
         # Request the anonymous page
         now = stable_now()
@@ -247,12 +244,12 @@ class TestProfileWithoutCaching(unittest.TestCase):
         )
         self.assertIn(testText, browser.contents)
         # This should use cacheInBrowser
-        self.assertEqual(
-            "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
-        )
-        tag = f'"||{catalog.getCounter()}|en|{default_skin}'
-        self.assertEqual(tag, _normalize_etag(browser.headers["ETag"]))
-        self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
+        self.assertEqual('max-age=0, must-revalidate, private',
+                         browser.headers['Cache-Control'])
+        tag = '"||{0}|en|{1}|0'.format(catalog.getCounter(), default_skin)
+        self.assertEqual(tag, _normalize_etag(browser.headers['ETag']))
+        self.assertGreater(now, dateutil.parser.parse(
+            browser.headers['Expires']))
 
         # Request the anonymous page again -- to test RAM cache.
         # Anonymous should be RAM cached
@@ -268,12 +265,12 @@ class TestProfileWithoutCaching(unittest.TestCase):
             "plone.app.caching.operations.ramcache", browser.headers["X-RAMCache"]
         )
         self.assertIn(testText, browser.contents)
-        self.assertEqual(
-            "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
-        )
-        tag = f'"||{catalog.getCounter()}|en|{default_skin}'
-        self.assertEqual(tag, _normalize_etag(browser.headers["ETag"]))
-        self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
+        self.assertEqual('max-age=0, must-revalidate, private',
+                         browser.headers['Cache-Control'])
+        tag = '"||{0}|en|{1}|0'.format(catalog.getCounter(), default_skin)
+        self.assertEqual(tag, _normalize_etag(browser.headers['ETag']))
+        self.assertGreater(now, dateutil.parser.parse(
+            browser.headers['Expires']))
 
         # Request the anonymous page again -- with an INM header to test 304.
         etag = browser.headers["ETag"]

--- a/plone/app/caching/tests/test_profile_without_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_without_caching_proxy.py
@@ -3,6 +3,7 @@ from plone.app.caching.testing import PLONE_APP_CACHING_FUNCTIONAL_RESTAPI_TESTI
 from plone.app.caching.testing import PLONE_APP_CACHING_FUNCTIONAL_TESTING
 from plone.app.caching.tests.test_utils import normalize_etag
 from plone.app.caching.tests.test_utils import stable_now
+from plone.app.caching.tests.test_utils import test_image
 from plone.app.testing import applyProfile
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
@@ -21,25 +22,7 @@ from zope.globalrequest import setRequest
 import datetime
 import dateutil.parser
 import dateutil.tz
-import io
-import os
-import pkg_resources
-import transaction
 import unittest
-
-
-TEST_FILE = pkg_resources.resource_filename("plone.app.caching.tests", "test.gif")
-
-
-def test_image():
-    from plone.namedfile.file import NamedBlobImage
-
-    filename = pkg_resources.resource_filename("plone.app.caching.tests", "test.gif")
-    filename = os.path.join(os.path.dirname(__file__), "test.gif")
-    return NamedBlobImage(
-        data=open(filename, "rb").read(),
-        filename=filename,
-    )
 
 
 class TestProfileWithoutCaching(unittest.TestCase):

--- a/plone/app/caching/tests/test_purge.py
+++ b/plone/app/caching/tests/test_purge.py
@@ -50,9 +50,8 @@ def getData(filename):
     from plone.app.caching import tests
 
     filename = join(dirname(tests.__file__), filename)
-    with open(filename, "rb") as fh:
-        data = fh.read()
-    return data
+    with open(filename, 'rb') as myfile:
+        return myfile.read()
 
 
 class Handler:

--- a/plone/app/caching/tests/test_purge.py
+++ b/plone/app/caching/tests/test_purge.py
@@ -35,7 +35,6 @@ from zope.component import provideUtility
 from zope.component import queryUtility
 from zope.component.event import objectEventNotify
 from zope.event import notify
-from zope.globalrequest import getRequest
 from zope.globalrequest import setRequest
 from zope.interface import implementer
 from zope.lifecycleevent import ObjectAddedEvent

--- a/plone/app/caching/tests/test_utils.py
+++ b/plone/app/caching/tests/test_utils.py
@@ -22,7 +22,7 @@ import unittest
 
 TEST_TIMEZONE = 'Europe/Vienna'
 TEST_IMAGE = pkg_resources.resource_filename(
-    'plone.app.caching.tests', 'test.gif')
+    u'plone.app.caching.tests', u'test.gif')
 
 
 def stable_now():

--- a/plone/app/caching/tests/test_utils.py
+++ b/plone/app/caching/tests/test_utils.py
@@ -15,11 +15,14 @@ from zope.component import provideAdapter
 from zope.component import provideUtility
 from zope.interface import implementer
 
+import pkg_resources
 import pytz
 import unittest
 
 
-TEST_TIMEZONE = "Europe/Vienna"
+TEST_TIMEZONE = 'Europe/Vienna'
+TEST_IMAGE = pkg_resources.resource_filename(
+    'plone.app.caching.tests', 'test.gif')
 
 
 def stable_now():
@@ -40,6 +43,15 @@ def normalize_etag(value):
         return '|'.join(split_value)
     # return original
     return value
+
+
+def test_image():
+    from plone.namedfile.file import NamedBlobImage
+    with open(TEST_IMAGE, 'rb') as myfile:
+        return NamedBlobImage(
+            data=myfile.read(),
+            filename=TEST_IMAGE,
+        )
 
 
 @implementer(IBrowserDefault, IDynamicType)

--- a/plone/app/caching/tests/test_utils.py
+++ b/plone/app/caching/tests/test_utils.py
@@ -1,4 +1,5 @@
 from Acquisition import Explicit
+from datetime import date
 from datetime import datetime
 from plone.app.caching.interfaces import IPloneCacheSettings
 from plone.app.caching.utils import getObjectDefaultView
@@ -27,6 +28,18 @@ def stable_now():
     now = datetime(2013, 5, 5, 10, 0, 0).replace(microsecond=0)
     now = tzinfo.localize(now)  # set tzinfo with correct DST offset
     return now
+
+
+def normalize_etag(value):
+    split_value = value.split('|')
+    # The last component is expected to be the resourceRegistries ETag,
+    # which is a time-based component, making it hard to test.
+    last = split_value.pop()
+    if str(date.today().year) in last:
+        # yes, this is time based, remove it
+        return '|'.join(split_value)
+    # return original
+    return value
 
 
 @implementer(IBrowserDefault, IDynamicType)


### PR DESCRIPTION
In `plone.app.caching` version 2, for Plone 5.2+, the `resourceRegistries` ETag was removed, because this ETag handled the old css/kss/js resource registry tools, which are gone now.  Good.
But there was no upgrade step for this, so for existing sites upgraded from 5.1 to 5.2, you get lots of warnings in the logs: "Could not find value adapter for ETag component resourceRegistries". I reported this in issue #61. In that issue, I propose several solutions.

This PR chooses (I think) the most elegant of the solutions: reintroduce the `resourceRegistries` ETag, but make it valid for the new-style Plone 5 resource registries. The ETag returns the timestamp from the production bundle: http://localhost:8080/Plone/portal_resources/resource_overrides/production/timestamp.txt/manage_main

The ETag is added to the same settings where it was previously, by partially reverting a commit. Where `catalogCounter` is, we add `resourceRegistries`, except in the feeds. Still sounds logical.

The assumption is that this ETag is still as useful and needed as it ever was, for the same reasons, and that the existing ETag should have already been updated in Plone 5.0, but this was overlooked. (Not that I blame anyone.)

While I was at it, I fixed a few minor issues in the tests, mostly unclosed files.

I don't think this needs migration:
- A Plone 5.1 site migrated to 5.2 will still have the `resourceRegistries` in the ETags, unless an admin removed them manually or with a policy package.
- A 5.2.2 site will not have it in the cache settings, but it's not so bad.
- We could add it in the settings, but we cannot really know if the admin wants it. Maybe some people have always removed this ETag in all their sites, already in Plone 4. Let's not mess with existing sites.
