### PR TITLE
Do not break if some custom code provides an alias for

### DIFF
--- a/news/72.bugfix
+++ b/news/72.bugfix
@@ -1,1 +1,1 @@
-Do not break if some custom code provides an alias for Products.Archetypes
+Do not break if some custom code provides an alias for Products.Archetypes or plone.app.blob

--- a/plone/app/caching/caching.zcml
+++ b/plone/app/caching/caching.zcml
@@ -143,7 +143,7 @@
     </configure>
 
     <!-- plone.app.blob content -->
-    <configure zcml:condition="installed plone.app.blob">
+    <configure zcml:condition="installed plone.app.blob.interfaces">
 
         <cache:ruleset ruleset="plone.content.file" for="plone.app.blob.interfaces.IATBlob" />
 


### PR DESCRIPTION
plone.app.blob

See also #73
Fixes #72 