### PR TITLE
Define etag for layout property.

### DIFF
--- a/news/80.feature
+++ b/news/80.feature
@@ -1,0 +1,4 @@
+Add etag for layout property.
+This is not yet added to a caching profile, but this can be done later.
+Fixes `issue 80 <https://github.com/plone/plone.app.caching/issues/80>`_.
+[maurits]

--- a/plone/app/caching/operations/configure.zcml
+++ b/plone/app/caching/operations/configure.zcml
@@ -44,5 +44,6 @@
     <adapter factory=".etags.ResourceRegistries"        name="resourceRegistries" />
     <adapter factory=".etags.AnonymousOrRandom"         name="anonymousOrRandom" />
     <adapter factory=".etags.CopyCookie"                name="copy" />
+    <adapter factory=".etags.Layout"                    name="layout" />
 
 </configure>

--- a/plone/app/caching/operations/etags.py
+++ b/plone/app/caching/operations/etags.py
@@ -1,3 +1,4 @@
+from Acquisition import aq_base
 from Acquisition import aq_inner
 from plone.app.caching.interfaces import IETagValue
 from plone.app.caching.operations.utils import getContext
@@ -7,6 +8,7 @@ from Products.CMFCore.interfaces import IMembershipTool
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.resources.browser.combine import get_override_directory
 from Products.CMFPlone.resources.browser.combine import PRODUCTION_RESOURCE_DIRECTORY
+from Products.CMFPlone.utils import safe_hasattr
 from zope.component import adapter
 from zope.component import queryMultiAdapter
 from zope.component import queryUtility
@@ -253,3 +255,19 @@ class ResourceRegistries(object):
         if not isinstance(timestamp, str):
             timestamp = timestamp.decode("utf-8")
         return timestamp
+
+
+@implementer(IETagValue)
+@adapter(Interface, Interface)
+class Layout(object):
+    """The 'layout' etag component, returning they layout of a content item."""
+
+    def __init__(self, published, request):
+        self.published = published
+        self.request = request
+
+    def __call__(self):
+        context = getContext(self.published)
+        if not safe_hasattr(aq_base(context), "getLayout"):
+            return
+        return context.getLayout()


### PR DESCRIPTION
For the moment this only defines the etag, without actually using it in a caching profile.
We can do this later.

When the layout changes, the modification date stays the same (currently).
So without this etag, you can get a page from the cache with the old layout.

Initially I had an etag for the default page as well.  This could be added to containers.
But the published item is then not the container, but the page.
And the page itself has no default page, so this etag never returned anything.