### PR TITLE
Add @@images/image to purge list for images

### DIFF
--- a/news/89.feature
+++ b/news/89.feature
@@ -1,0 +1,1 @@
+When purging images also purge the field WITHOUT a size parameter (e.g. [...]/@@images/image)

--- a/plone/app/caching/purge.py
+++ b/plone/app/caching/purge.py
@@ -208,6 +208,7 @@ class ScalesPurgePaths:
                     continue
                 filename = value.filename
                 if is_image:
+                    yield f"{prefix}/@@images/image"
                     for size in self.getScales():
                         yield f"{prefix}/images/{field_name}/{size}"
                         yield f"{prefix}/@@images/{field_name}/{size}"

--- a/plone/app/caching/purge.py
+++ b/plone/app/caching/purge.py
@@ -208,7 +208,7 @@ class ScalesPurgePaths:
                     continue
                 filename = value.filename
                 if is_image:
-                    yield f"{prefix}/@@images/image"
+                    yield f"{prefix}/@@images/{field_name}"
                     for size in self.getScales():
                         yield f"{prefix}/images/{field_name}/{size}"
                         yield f"{prefix}/@@images/{field_name}/{size}"


### PR DESCRIPTION
The `@@images/image` path is used when embedding image documents in a document. This also needs to be purged when updating an image document. 