### PR TITLE
Update weird changes in ETAG headers when combine_bundles is gone

### DIFF
--- a/news/92.bugfix
+++ b/news/92.bugfix
@@ -1,0 +1,2 @@
+Caching checks for timestamp.txt in portal_resources which is no longer there. Update ETAG Headers accordingly.
+[pbauer]

--- a/plone/app/caching/tests/test_profile_with_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_with_caching_proxy.py
@@ -133,7 +133,7 @@ class TestProfileWithCaching(unittest.TestCase):
             "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
         )
         self.assertEqual(
-            '"|test_user_1_|%d|en|%s|0|0'
+            '"|test_user_1_|%d|en|%s|0|0|"'
             % (catalog.getCounter(), skins_tool.default_skin),
             normalize_etag(browser.headers["ETag"]),
         )
@@ -151,7 +151,7 @@ class TestProfileWithCaching(unittest.TestCase):
             "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
         )
         self.assertEqual(
-            '"|test_user_1_|%d|en|%s|0|1'
+            '"|test_user_1_|%d|en|%s|0|1|"'
             % (catalog.getCounter(), skins_tool.default_skin),
             normalize_etag(browser.headers["ETag"]),
         )
@@ -177,7 +177,7 @@ class TestProfileWithCaching(unittest.TestCase):
             "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
         )
         self.assertEqual(
-            '"|test_user_1_|%d|en|%s|0'
+            '"|test_user_1_|%d|en|%s|0|"'
             % (catalog.getCounter(), skins_tool.default_skin),
             normalize_etag(browser.headers["ETag"]),
         )
@@ -232,7 +232,7 @@ class TestProfileWithCaching(unittest.TestCase):
             "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
         )
         self.assertEqual(
-            '"||%d|en|%s|0|0' % (catalog.getCounter(), skins_tool.default_skin),
+            '"||%d|en|%s|0|0|"' % (catalog.getCounter(), skins_tool.default_skin),
             normalize_etag(browser.headers["ETag"]),
         )
         self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
@@ -251,7 +251,7 @@ class TestProfileWithCaching(unittest.TestCase):
             "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
         )
         self.assertEqual(
-            '"||%d|en|%s|0' % (catalog.getCounter(), skins_tool.default_skin),
+            '"||%d|en|%s|0|"' % (catalog.getCounter(), skins_tool.default_skin),
             normalize_etag(browser.headers["ETag"]),
         )
         self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
@@ -274,7 +274,7 @@ class TestProfileWithCaching(unittest.TestCase):
             "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
         )
         self.assertEqual(
-            '"||%d|en|%s|0' % (catalog.getCounter(), skins_tool.default_skin),
+            '"||%d|en|%s|0|"' % (catalog.getCounter(), skins_tool.default_skin),
             normalize_etag(browser.headers["ETag"]),
         )
         self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))

--- a/plone/app/caching/tests/test_profile_without_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_without_caching_proxy.py
@@ -116,7 +116,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         self.assertEqual(
             "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
         )
-        tag = '"|test_user_1_|{0}|en|{1}|0|0'.format(
+        tag = '"|test_user_1_|{0}|en|{1}|0|0|"'.format(
             catalog.getCounter(),
             default_skin,
         )
@@ -134,7 +134,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         self.assertEqual(
             "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
         )
-        tag = '"|test_user_1_|{0}|en|{1}|0|1'.format(
+        tag = '"|test_user_1_|{0}|en|{1}|0|1|"'.format(
             catalog.getCounter(),
             default_skin,
         )
@@ -160,7 +160,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         self.assertEqual(
             "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
         )
-        tag = '"|test_user_1_|{0}|en|{1}|0'.format(
+        tag = '"|test_user_1_|{0}|en|{1}|0|"'.format(
             catalog.getCounter(),
             default_skin,
         )
@@ -214,7 +214,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         self.assertEqual(
             "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
         )
-        tag = '"||{0}|en|{1}|0|0'.format(catalog.getCounter(), default_skin)
+        tag = '"||{0}|en|{1}|0|0|"'.format(catalog.getCounter(), default_skin)
         self.assertEqual(tag, normalize_etag(browser.headers["ETag"]))
         self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
 
@@ -231,7 +231,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         self.assertEqual(
             "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
         )
-        tag = '"||{0}|en|{1}|0'.format(catalog.getCounter(), default_skin)
+        tag = '"||{0}|en|{1}|0|"'.format(catalog.getCounter(), default_skin)
         self.assertEqual(tag, normalize_etag(browser.headers["ETag"]))
         self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
 
@@ -252,7 +252,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         self.assertEqual(
             "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
         )
-        tag = '"||{0}|en|{1}|0'.format(catalog.getCounter(), default_skin)
+        tag = '"||{0}|en|{1}|0|"'.format(catalog.getCounter(), default_skin)
         self.assertEqual(tag, normalize_etag(browser.headers["ETag"]))
         self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
 


### PR DESCRIPTION
plone.app.caching used to check for timestamp.txt in portal_resources whcih is no longer there