### PR TITLE
Fix tests to work with the Zope security fix. [master]

### DIFF
--- a/news/106.bugfix
+++ b/news/106.bugfix
@@ -1,0 +1,2 @@
+Fix tests to work with the Zope security fix.
+[maurits]

--- a/plone/app/caching/tests/test_profile_with_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_with_caching_proxy.py
@@ -199,7 +199,7 @@ class TestProfileWithCaching(unittest.TestCase):
         browser.open(self.portal["f1"]["d1"].absolute_url())
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual(b"", browser.contents)
+        self.assertEqual("", browser.contents)
 
         # Request the anonymous folder
         now = stable_now()
@@ -274,7 +274,7 @@ class TestProfileWithCaching(unittest.TestCase):
         )
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual(b"", browser.contents)
+        self.assertEqual("", browser.contents)
 
         # Edit the page to update the etag
         testText2 = "Testing... body two"
@@ -369,7 +369,7 @@ class TestProfileWithCaching(unittest.TestCase):
         )
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual(b"", browser.contents)
+        self.assertEqual("", browser.contents)
 
         # Request the authenticated rss feed
         now = stable_now()
@@ -504,7 +504,7 @@ class TestProfileWithCaching(unittest.TestCase):
         )
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual(b"", browser.contents)
+        self.assertEqual("", browser.contents)
 
         # Request an image scale
         now = stable_now()
@@ -560,7 +560,7 @@ class TestProfileWithCaching(unittest.TestCase):
         )
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual(b"", browser.contents)
+        self.assertEqual("", browser.contents)
 
         # Request a large datafile (over 64K) to test files that use
         # the "response.write()" function to initiate a streamed response.

--- a/plone/app/caching/tests/test_profile_without_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_without_caching_proxy.py
@@ -177,7 +177,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         browser.open(self.portal["f1"]["d1"].absolute_url())
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual(b"", browser.contents)
+        self.assertEqual("", browser.contents)
 
         # Request the anonymous folder
         now = stable_now()
@@ -245,7 +245,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         )
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual(b"", browser.contents)
+        self.assertEqual("", browser.contents)
 
         # Edit the page to update the etag
         testText2 = "Testing... body two"
@@ -334,7 +334,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         )
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual(b"", browser.contents)
+        self.assertEqual("", browser.contents)
 
         # Request the authenticated rss feed
         now = stable_now()
@@ -421,7 +421,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         )
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual(b"", browser.contents)
+        self.assertEqual("", browser.contents)
 
         # Request an image scale
         now = stable_now()
@@ -471,7 +471,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         )
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual(b"", browser.contents)
+        self.assertEqual("", browser.contents)
 
         # Request a large datafile (over 64K) to test files that use
         # the "response.write()" function to initiate a streamed response.


### PR DESCRIPTION
Instead of an empty byte we get an empty text now.  I don't know what in the security fix causes this, but seems okay.