### PR TITLE
Fix tests to work with the Zope security fix. [Plone 5]

### DIFF
--- a/news/106.bugfix
+++ b/news/106.bugfix
@@ -1,0 +1,2 @@
+Fix tests to work with the Zope security fix.
+[maurits]

--- a/plone/app/caching/tests/test_profile_with_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_with_caching_proxy.py
@@ -69,6 +69,11 @@ class TestProfileWithCaching(unittest.TestCase):
     def tearDown(self):
         setRequest(None)
 
+    def assertBrowserEmpty(self, browser):
+        # assert that browser.contents is an empty bytes/string/unicode.
+        self.assertIsInstance(browser.contents, (six.binary_type, six.text_type))
+        self.assertFalse(browser.contents)
+
     def test_composite_viewsxx(self):
         # This is a clone of the same test for 'without-caching-proxy'
         # Can we just call that test from this context?
@@ -193,7 +198,7 @@ class TestProfileWithCaching(unittest.TestCase):
         browser.open(self.portal['f1']['d1'].absolute_url())
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertEqual(b'', browser.contents)
+        self.assertBrowserEmpty(browser)
 
         # Request the anonymous folder
         now = stable_now()
@@ -261,7 +266,7 @@ class TestProfileWithCaching(unittest.TestCase):
                          browser.headers['X-Cache-Operation'])
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertEqual(b'', browser.contents)
+        self.assertBrowserEmpty(browser)
 
         # Edit the page to update the etag
         testText2 = 'Testing... body two'
@@ -354,7 +359,7 @@ class TestProfileWithCaching(unittest.TestCase):
                          browser.headers['X-Cache-Operation'])
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertEqual(b'', browser.contents)
+        self.assertBrowserEmpty(browser)
 
         # Request the authenticated rss feed
         now = stable_now()
@@ -484,7 +489,7 @@ class TestProfileWithCaching(unittest.TestCase):
                          browser.headers['X-Cache-Operation'])
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertEqual(b'', browser.contents)
+        self.assertBrowserEmpty(browser)
 
         # Request an image scale
         now = stable_now()
@@ -535,7 +540,7 @@ class TestProfileWithCaching(unittest.TestCase):
                          browser.headers['X-Cache-Operation'])
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertEqual(b'', browser.contents)
+        self.assertBrowserEmpty(browser)
 
         # Request a large datafile (over 64K) to test files that use
         # the "response.write()" function to initiate a streamed response.

--- a/plone/app/caching/tests/test_profile_without_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_without_caching_proxy.py
@@ -57,6 +57,11 @@ class TestProfileWithoutCaching(unittest.TestCase):
     def tearDown(self):
         setRequest(None)
 
+    def assertBrowserEmpty(self, browser):
+        # assert that browser.contents is an empty bytes/string/unicode.
+        self.assertIsInstance(browser.contents, (six.binary_type, six.text_type))
+        self.assertFalse(browser.contents)
+
     def test_composite_views(self):
 
         catalog = self.portal['portal_catalog']
@@ -188,7 +193,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         browser.open(self.portal['f1']['d1'].absolute_url())
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertEqual(b'', browser.contents)
+        self.assertBrowserEmpty(browser)
 
         # Request the anonymous folder
         now = stable_now()
@@ -255,7 +260,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
                          browser.headers['X-Cache-Operation'])
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertEqual(b'', browser.contents)
+        self.assertBrowserEmpty(browser)
 
         # Edit the page to update the etag
         testText2 = 'Testing... body two'
@@ -341,7 +346,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
                          browser.headers['X-Cache-Operation'])
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertEqual(b'', browser.contents)
+        self.assertBrowserEmpty(browser)
 
         # Request the authenticated rss feed
         now = stable_now()
@@ -427,7 +432,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
                          browser.headers['X-Cache-Operation'])
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertEqual(b'', browser.contents)
+        self.assertBrowserEmpty(browser)
 
         # Request an image scale
         now = stable_now()
@@ -476,7 +481,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
                          browser.headers['X-Cache-Operation'])
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertEqual(b'', browser.contents)
+        self.assertBrowserEmpty(browser)
 
         # Request a large datafile (over 64K) to test files that use
         # the "response.write()" function to initiate a streamed response.


### PR DESCRIPTION
Accept binary and text type, as long as it is empty. Fixes https://github.com/plone/plone.app.caching/issues/106