### PR TITLE
Revert changes to tests to work with the Zope security fix. [master]

### DIFF
--- a/news/1089.bugfix
+++ b/news/1089.bugfix
@@ -1,0 +1,4 @@
+Revert changes to tests to work with the Zope security fix.
+We must have an empty byte, not text, otherwise it is an indication that we get a possibly wrong Content-Type in a 304 status.
+See `Zope issue 1089 <https://github.com/zopefoundation/Zope/issues/1089>`_.
+[maurits]

--- a/plone/app/caching/tests/test_profile_with_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_with_caching_proxy.py
@@ -199,7 +199,11 @@ class TestProfileWithCaching(unittest.TestCase):
         browser.open(self.portal["f1"]["d1"].absolute_url())
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual("", browser.contents)
+        # We MUST have an empty byte, not text, otherwise it is an indication that we
+        # get a possibly wrong Content-Type in a 304 status.
+        # See https://github.com/zopefoundation/Zope/issues/1089.
+        self.assertEqual(b"", browser.contents)
+        self.assertFalse(browser.headers["Content-Type"])
 
         # Request the anonymous folder
         now = stable_now()
@@ -274,7 +278,8 @@ class TestProfileWithCaching(unittest.TestCase):
         )
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual("", browser.contents)
+        self.assertEqual(b"", browser.contents)
+        self.assertFalse(browser.headers["Content-Type"])
 
         # Edit the page to update the etag
         testText2 = "Testing... body two"
@@ -369,7 +374,8 @@ class TestProfileWithCaching(unittest.TestCase):
         )
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual("", browser.contents)
+        self.assertEqual(b"", browser.contents)
+        self.assertFalse(browser.headers["Content-Type"])
 
         # Request the authenticated rss feed
         now = stable_now()
@@ -504,7 +510,8 @@ class TestProfileWithCaching(unittest.TestCase):
         )
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual("", browser.contents)
+        self.assertEqual(b"", browser.contents)
+        self.assertFalse(browser.headers["Content-Type"])
 
         # Request an image scale
         now = stable_now()
@@ -560,7 +567,8 @@ class TestProfileWithCaching(unittest.TestCase):
         )
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual("", browser.contents)
+        self.assertEqual(b"", browser.contents)
+        self.assertFalse(browser.headers["Content-Type"])
 
         # Request a large datafile (over 64K) to test files that use
         # the "response.write()" function to initiate a streamed response.

--- a/plone/app/caching/tests/test_profile_without_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_without_caching_proxy.py
@@ -177,7 +177,11 @@ class TestProfileWithoutCaching(unittest.TestCase):
         browser.open(self.portal["f1"]["d1"].absolute_url())
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual("", browser.contents)
+        # We MUST have an empty byte, not text, otherwise it is an indication that we
+        # get a possibly wrong Content-Type in a 304 status.
+        # See https://github.com/zopefoundation/Zope/issues/1089.
+        self.assertEqual(b"", browser.contents)
+        self.assertFalse(browser.headers["Content-Type"])
 
         # Request the anonymous folder
         now = stable_now()
@@ -245,7 +249,8 @@ class TestProfileWithoutCaching(unittest.TestCase):
         )
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual("", browser.contents)
+        self.assertEqual(b"", browser.contents)
+        self.assertFalse(browser.headers["Content-Type"])
 
         # Edit the page to update the etag
         testText2 = "Testing... body two"
@@ -334,7 +339,8 @@ class TestProfileWithoutCaching(unittest.TestCase):
         )
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual("", browser.contents)
+        self.assertEqual(b"", browser.contents)
+        self.assertFalse(browser.headers["Content-Type"])
 
         # Request the authenticated rss feed
         now = stable_now()
@@ -421,7 +427,8 @@ class TestProfileWithoutCaching(unittest.TestCase):
         )
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual("", browser.contents)
+        self.assertEqual(b"", browser.contents)
+        self.assertFalse(browser.headers["Content-Type"])
 
         # Request an image scale
         now = stable_now()
@@ -471,7 +478,8 @@ class TestProfileWithoutCaching(unittest.TestCase):
         )
         # This should be a 304 response
         self.assertEqual("304 Not Modified", browser.headers["Status"])
-        self.assertEqual("", browser.contents)
+        self.assertEqual(b"", browser.contents)
+        self.assertFalse(browser.headers["Content-Type"])
 
         # Request a large datafile (over 64K) to test files that use
         # the "response.write()" function to initiate a streamed response.


### PR DESCRIPTION
We must have an empty byte, not text, otherwise it is an indication that we get a possibly wrong Content-Type in a 304 status. See https://github.com/zopefoundation/Zope/issues/1089.

This reverts commit e6941fdfe6c8a3c98af98f4986e6932739adfca6.