### PR TITLE
Revert changes to tests to work with the Zope security fix.

### DIFF
--- a/news/1089.bugfix
+++ b/news/1089.bugfix
@@ -1,0 +1,4 @@
+Revert changes to tests to work with the Zope security fix.
+We must have an empty byte, not text, otherwise it is an indication that we get a possibly wrong Content-Type in a 304 status.
+See `Zope issue 1089 <https://github.com/zopefoundation/Zope/issues/1089>`_.
+[maurits]

--- a/plone/app/caching/tests/test_profile_with_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_with_caching_proxy.py
@@ -69,11 +69,6 @@ class TestProfileWithCaching(unittest.TestCase):
     def tearDown(self):
         setRequest(None)
 
-    def assertBrowserEmpty(self, browser):
-        # assert that browser.contents is an empty bytes/string/unicode.
-        self.assertIsInstance(browser.contents, (six.binary_type, six.text_type))
-        self.assertFalse(browser.contents)
-
     def test_composite_viewsxx(self):
         # This is a clone of the same test for 'without-caching-proxy'
         # Can we just call that test from this context?
@@ -198,7 +193,11 @@ class TestProfileWithCaching(unittest.TestCase):
         browser.open(self.portal['f1']['d1'].absolute_url())
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertBrowserEmpty(browser)
+        # We MUST have an empty byte, not text, otherwise it is an indication that we
+        # get a possibly wrong Content-Type in a 304 status.
+        # See https://github.com/zopefoundation/Zope/issues/1089.
+        self.assertEqual(b'', browser.contents)
+        self.assertFalse(browser.headers['Content-Type'])
 
         # Request the anonymous folder
         now = stable_now()
@@ -266,7 +265,8 @@ class TestProfileWithCaching(unittest.TestCase):
                          browser.headers['X-Cache-Operation'])
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertBrowserEmpty(browser)
+        self.assertEqual(b'', browser.contents)
+        self.assertFalse(browser.headers['Content-Type'])
 
         # Edit the page to update the etag
         testText2 = 'Testing... body two'
@@ -359,7 +359,8 @@ class TestProfileWithCaching(unittest.TestCase):
                          browser.headers['X-Cache-Operation'])
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertBrowserEmpty(browser)
+        self.assertEqual(b'', browser.contents)
+        self.assertFalse(browser.headers['Content-Type'])
 
         # Request the authenticated rss feed
         now = stable_now()
@@ -489,7 +490,8 @@ class TestProfileWithCaching(unittest.TestCase):
                          browser.headers['X-Cache-Operation'])
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertBrowserEmpty(browser)
+        self.assertEqual(b'', browser.contents)
+        self.assertFalse(browser.headers['Content-Type'])
 
         # Request an image scale
         now = stable_now()
@@ -540,7 +542,8 @@ class TestProfileWithCaching(unittest.TestCase):
                          browser.headers['X-Cache-Operation'])
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertBrowserEmpty(browser)
+        self.assertEqual(b'', browser.contents)
+        self.assertFalse(browser.headers['Content-Type'])
 
         # Request a large datafile (over 64K) to test files that use
         # the "response.write()" function to initiate a streamed response.

--- a/plone/app/caching/tests/test_profile_with_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_with_caching_proxy.py
@@ -197,7 +197,7 @@ class TestProfileWithCaching(unittest.TestCase):
         # get a possibly wrong Content-Type in a 304 status.
         # See https://github.com/zopefoundation/Zope/issues/1089.
         self.assertEqual(b'', browser.contents)
-        self.assertFalse(browser.headers['Content-Type'])
+        self.assertFalse(browser.headers.get('Content-Type'))
 
         # Request the anonymous folder
         now = stable_now()
@@ -266,7 +266,7 @@ class TestProfileWithCaching(unittest.TestCase):
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
         self.assertEqual(b'', browser.contents)
-        self.assertFalse(browser.headers['Content-Type'])
+        self.assertFalse(browser.headers.get('Content-Type'))
 
         # Edit the page to update the etag
         testText2 = 'Testing... body two'
@@ -360,7 +360,7 @@ class TestProfileWithCaching(unittest.TestCase):
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
         self.assertEqual(b'', browser.contents)
-        self.assertFalse(browser.headers['Content-Type'])
+        self.assertFalse(browser.headers.get('Content-Type'))
 
         # Request the authenticated rss feed
         now = stable_now()
@@ -491,7 +491,7 @@ class TestProfileWithCaching(unittest.TestCase):
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
         self.assertEqual(b'', browser.contents)
-        self.assertFalse(browser.headers['Content-Type'])
+        self.assertFalse(browser.headers.get('Content-Type'))
 
         # Request an image scale
         now = stable_now()
@@ -543,7 +543,7 @@ class TestProfileWithCaching(unittest.TestCase):
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
         self.assertEqual(b'', browser.contents)
-        self.assertFalse(browser.headers['Content-Type'])
+        self.assertFalse(browser.headers.get('Content-Type'))
 
         # Request a large datafile (over 64K) to test files that use
         # the "response.write()" function to initiate a streamed response.

--- a/plone/app/caching/tests/test_profile_without_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_without_caching_proxy.py
@@ -192,7 +192,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         # get a possibly wrong Content-Type in a 304 status.
         # See https://github.com/zopefoundation/Zope/issues/1089.
         self.assertEqual(b'', browser.contents)
-        self.assertFalse(browser.headers['Content-Type'])
+        self.assertFalse(browser.headers.get('Content-Type'))
 
         # Request the anonymous folder
         now = stable_now()
@@ -260,7 +260,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
         self.assertEqual(b'', browser.contents)
-        self.assertFalse(browser.headers['Content-Type'])
+        self.assertFalse(browser.headers.get('Content-Type'))
 
         # Edit the page to update the etag
         testText2 = 'Testing... body two'
@@ -347,7 +347,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
         self.assertEqual(b'', browser.contents)
-        self.assertFalse(browser.headers['Content-Type'])
+        self.assertFalse(browser.headers.get('Content-Type'))
 
         # Request the authenticated rss feed
         now = stable_now()
@@ -434,7 +434,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
         self.assertEqual(b'', browser.contents)
-        self.assertFalse(browser.headers['Content-Type'])
+        self.assertFalse(browser.headers.get('Content-Type'))
 
         # Request an image scale
         now = stable_now()
@@ -484,7 +484,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
         self.assertEqual(b'', browser.contents)
-        self.assertFalse(browser.headers['Content-Type'])
+        self.assertFalse(browser.headers.get('Content-Type'))
 
         # Request a large datafile (over 64K) to test files that use
         # the "response.write()" function to initiate a streamed response.

--- a/plone/app/caching/tests/test_profile_without_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_without_caching_proxy.py
@@ -57,11 +57,6 @@ class TestProfileWithoutCaching(unittest.TestCase):
     def tearDown(self):
         setRequest(None)
 
-    def assertBrowserEmpty(self, browser):
-        # assert that browser.contents is an empty bytes/string/unicode.
-        self.assertIsInstance(browser.contents, (six.binary_type, six.text_type))
-        self.assertFalse(browser.contents)
-
     def test_composite_views(self):
 
         catalog = self.portal['portal_catalog']
@@ -193,7 +188,11 @@ class TestProfileWithoutCaching(unittest.TestCase):
         browser.open(self.portal['f1']['d1'].absolute_url())
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertBrowserEmpty(browser)
+        # We MUST have an empty byte, not text, otherwise it is an indication that we
+        # get a possibly wrong Content-Type in a 304 status.
+        # See https://github.com/zopefoundation/Zope/issues/1089.
+        self.assertEqual(b'', browser.contents)
+        self.assertFalse(browser.headers['Content-Type'])
 
         # Request the anonymous folder
         now = stable_now()
@@ -260,7 +259,8 @@ class TestProfileWithoutCaching(unittest.TestCase):
                          browser.headers['X-Cache-Operation'])
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertBrowserEmpty(browser)
+        self.assertEqual(b'', browser.contents)
+        self.assertFalse(browser.headers['Content-Type'])
 
         # Edit the page to update the etag
         testText2 = 'Testing... body two'
@@ -346,7 +346,8 @@ class TestProfileWithoutCaching(unittest.TestCase):
                          browser.headers['X-Cache-Operation'])
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertBrowserEmpty(browser)
+        self.assertEqual(b'', browser.contents)
+        self.assertFalse(browser.headers['Content-Type'])
 
         # Request the authenticated rss feed
         now = stable_now()
@@ -432,7 +433,8 @@ class TestProfileWithoutCaching(unittest.TestCase):
                          browser.headers['X-Cache-Operation'])
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertBrowserEmpty(browser)
+        self.assertEqual(b'', browser.contents)
+        self.assertFalse(browser.headers['Content-Type'])
 
         # Request an image scale
         now = stable_now()
@@ -481,7 +483,8 @@ class TestProfileWithoutCaching(unittest.TestCase):
                          browser.headers['X-Cache-Operation'])
         # This should be a 304 response
         self.assertEqual('304 Not Modified', browser.headers['Status'])
-        self.assertBrowserEmpty(browser)
+        self.assertEqual(b'', browser.contents)
+        self.assertFalse(browser.headers['Content-Type'])
 
         # Request a large datafile (over 64K) to test files that use
         # the "response.write()" function to initiate a streamed response.


### PR DESCRIPTION
We must have an empty byte, not text, otherwise it is an indication that we get a possibly wrong Content-Type in a 304 status. See https://github.com/zopefoundation/Zope/issues/1089.

This reverts commit 52885bf0f81ccb655196a65226e424ae74b9b253.