### PR TITLE
Apply weak caching to GET requests of content with application/json.

### DIFF
--- a/news/73.bugfix
+++ b/news/73.bugfix
@@ -1,0 +1,3 @@
+Apply weak caching to GET requests of content with application/json.
+See `plone.rest issue 73 <https://github.com/plone/plone.rest/issues/73>`_.
+[maurits]

--- a/plone/app/caching/profiles/default/registry.xml
+++ b/plone/app/caching/profiles/default/registry.xml
@@ -29,6 +29,7 @@
           <element key="file_view">plone.content.itemView</element>
           <element key="image_view">plone.content.itemView</element>
           <element key="image_view_fullscreen">plone.content.itemView</element>
+          <element key="GET_application_json_">plone.content.folderView</element>
         </value>
     </record>
 


### PR DESCRIPTION
See https://github.com/plone/plone.rest/issues/73. This is for Plone 5.2 only.

Note: this needs an upgrade step, but we will do this in plone.app.upgrade. The plone.app.caching master branch already has an update to metadata version 2, so there is no room for an upgrade step on the 2.x branch.

Also note that it should not be needed to undo this change on Plone 6: there the plone.content.dynamic ruleset will be applied, and this takes precedence over the current change.