### PR TITLE
Config with default template 2e5ff797

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/plone/meta/tree/master/config/default
 [meta]
 template = "default"
-commit-id = "0e4e67b6"
+commit-id = "66035512"
 
 [dependencies]
 mappings = [

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+# Generated from:
+# https://github.com/plone/meta/tree/master/config/default
+ci:
+    autofix_prs: false
+    autoupdate_schedule: monthly
+
+repos:
+-   repo: https://github.com/asottile/pyupgrade
+    rev: v3.3.1
+    hooks:
+    -   id: pyupgrade
+        args: [--py38-plus]
+-   repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+    -   id: isort
+-   repo: https://github.com/ambv/black
+    rev: 23.1.0
+    hooks:
+    -   id: black
+-   repo: https://github.com/collective/zpretty
+    rev: 3.0.1
+    hooks:
+    -   id: zpretty
+-   repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+    -   id: flake8
+-   repo: https://github.com/codespell-project/codespell
+    rev: v2.2.2
+    hooks:
+    -   id: codespell
+-   repo: https://github.com/mgedmin/check-manifest
+    rev: "0.49"
+    hooks:
+    -   id: check-manifest
+-   repo: https://github.com/regebro/pyroma
+    rev: "4.1"
+    hooks:
+    -   id: pyroma

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,10 +26,6 @@ repos:
     rev: 6.0.0
     hooks:
     -   id: flake8
--   repo: https://github.com/codespell-project/codespell
-    rev: v2.2.2
-    hooks:
-    -   id: codespell
 -   repo: https://github.com/mgedmin/check-manifest
     rev: "0.49"
     hooks:

--- a/news/66035512.internal
+++ b/news/66035512.internal
@@ -1,0 +1,2 @@
+Update configuration files.
+[plone devs]

--- a/news/66035512.internal
+++ b/news/66035512.internal
@@ -1,2 +1,2 @@
-Update configuration files.
+Update configuration files to plone/meta.
 [plone devs]

--- a/plone/app/caching/browser/controlpanel.pt
+++ b/plone/app/caching/browser/controlpanel.pt
@@ -629,7 +629,7 @@
                                                     </div>
                                                     <div style="white-space: nowrap" class="discreet rulesetParameterLink" tal:condition="operationInfo/hasOptions">
                                                         <a  class="editGlobalOperationParameters pat-plone-modal"
-                                                            data-pat-plone-modal='{"actionOptions": {"disableAjaxFormSubmit":true}}'
+                                                            data-pat-plone-modal="{'actionOptions': {'disableAjaxFormSubmit':true}}"
                                                             i18n:translate="link_view_edit"
                                                             tal:attributes="href string:${context/absolute_url}/@@${view/__name__}/edit-operation-global/${operationName}"
                                                             >View/edit</a>
@@ -638,13 +638,13 @@
                                                     <div style="white-space: nowrap" class="discreet rulesetParameterLink"  tal:condition="operationInfo/hasOptions">
                                                         <tal:block define="hasRulesetOptions python:view.hasRulesetOptions(operationInfo['type'], ruleType['name'])">
                                                             <a  class="editRulesetOperationParameters pat-plone-modal"
-                                                                data-pat-plone-modal='{"actionOptions": {"disableAjaxFormSubmit":true}}'
+                                                                data-pat-plone-modal="{'actionOptions': {'disableAjaxFormSubmit':true}}"
                                                                 tal:condition="hasRulesetOptions"
                                                                 i18n:translate="link_view_edit_clear"
                                                                 tal:attributes="href string:${context/absolute_url}/@@${view/__name__}/edit-operation-ruleset/${operationName}/${ruleType/name}"
                                                                 >View/edit/clear</a>
                                                             <a  class="editRulesetOperationParameters pat-plone-modal"
-                                                                data-pat-plone-modal='{"actionOptions": {"disableAjaxFormSubmit":true}}'
+                                                                data-pat-plone-modal="{'actionOptions': {'disableAjaxFormSubmit':true}}"
                                                                 tal:condition="not:hasRulesetOptions"
                                                                 i18n:translate="link_create"
                                                                 tal:attributes="href string:${context/absolute_url}/@@${view/__name__}/edit-operation-ruleset/${operationName}/${ruleType/name}"

--- a/plone/app/caching/browser/controlpanel.pt
+++ b/plone/app/caching/browser/controlpanel.pt
@@ -1,16 +1,18 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
-      xmlns:tal="http://xml.zope.org/namespaces/tal"
-      xmlns:metal="http://xml.zope.org/namespaces/metal"
+<html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    lang="en"
-    metal:use-macro="context/prefs_main_template/macros/master"
-    i18n:domain="plone">
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      lang="en"
+      metal:use-macro="context/prefs_main_template/macros/master"
+      xml:lang="en"
+      i18n:domain="plone"
+>
 
-<body>
+  <body>
 
-<div metal:fill-slot="prefs_configlet_main">
+    <div metal:fill-slot="prefs_configlet_main">
 
-<script type="text/javascript">
+      <script type="text/javascript">
 (function($) {
 
     if($.fn.prepOverlay){
@@ -26,279 +28,400 @@
     }
 
 })(jQuery);
-</script>
+      </script>
 
-    <div class="autotabs">
+      <div class="autotabs">
         <ul class="nav nav-tabs">
-            <li class="nav-item">
-                <a href=""
-                   class="nav-link active"
-                   tal:attributes="href string:${portal_url}/@@caching-controlpanel"
-                   i18n:translate="label_settings">Change settings</a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link"
-                   href=""
-                   tal:attributes="href string:${portal_url}/@@caching-controlpanel-import"
-                   i18n:translate="label_import">Import settings</a>
-              </li>
-              <li tal:condition="view/purgingEnabled" class="nav-item">
-                <a class="nav-link"
-                   href=""
-                   tal:attributes="href string:${portal_url}/@@caching-controlpanel-purge"
-                   i18n:translate="label_purging">Purge caching proxy</a>
-              </li>
-              <li class="nav-item">
-                <a class="nav-link"
-                   href=""
-                   tal:attributes="href string:${portal_url}/@@caching-controlpanel-ramcache"
-                   i18n:translate="label_ramcache">RAM cache</a>
-              </li>
+          <li class="nav-item">
+            <a class="nav-link active"
+               href=""
+               tal:attributes="
+                 href string:${portal_url}/@@caching-controlpanel;
+               "
+               i18n:translate="label_settings"
+            >Change settings</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link"
+               href=""
+               tal:attributes="
+                 href string:${portal_url}/@@caching-controlpanel-import;
+               "
+               i18n:translate="label_import"
+            >Import settings</a>
+          </li>
+          <li class="nav-item"
+              tal:condition="view/purgingEnabled"
+          >
+            <a class="nav-link"
+               href=""
+               tal:attributes="
+                 href string:${portal_url}/@@caching-controlpanel-purge;
+               "
+               i18n:translate="label_purging"
+            >Purge caching proxy</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link"
+               href=""
+               tal:attributes="
+                 href string:${portal_url}/@@caching-controlpanel-ramcache;
+               "
+               i18n:translate="label_ramcache"
+            >RAM cache</a>
+          </li>
         </ul>
-    </div>
+      </div>
 
-    <div class="alert alert-info"
-         role="alert"
-        tal:condition="not: view/settings/enabled">
+      <div class="alert alert-info"
+           role="alert"
+           tal:condition="not: view/settings/enabled"
+      >
         <strong i18n:translate="">
             Info
         </strong>
         <span tal:omit-tag=""
-            i18n:translate="label_caching_first_time_here?">
+              i18n:translate="label_caching_first_time_here?"
+        >
             First time here? We recommend that you get started by
-            <a href="@@caching-controlpanel-import"
-               tal:attributes="href string:${context/absolute_url}/@@caching-controlpanel-import"
-               title="Import caching rules"
-               i18n:name="link"
-               i18n:attributes="title label_import_caching_rules"
-               i18n:translate="label_caching_first_time_here_link"
-               >importing a preconfigured set of caching rules</a>.
+          <a href="@@caching-controlpanel-import"
+             title="Import caching rules"
+             tal:attributes="
+               href string:${context/absolute_url}/@@caching-controlpanel-import;
+             "
+             i18n:attributes="title label_import_caching_rules"
+             i18n:name="link"
+             i18n:translate="label_caching_first_time_here_link"
+          >importing a preconfigured set of caching rules</a>.
         </span>
-    </div>
+      </div>
 
-    <div metal:use-macro="context/global_statusmessage/macros/portal_message">
+      <div metal:use-macro="context/global_statusmessage/macros/portal_message">
     Portal status message
-    </div>
+      </div>
 
 
-            <div class="configlet">
+      <div class="configlet">
 
-                <h1 class="documentFirstHeading"
-                    i18n:translate="heading_caching_settings">Caching settings</h1>
+        <h1 class="documentFirstHeading"
+            i18n:translate="heading_caching_settings"
+        >Caching settings</h1>
 
 
-                <p i18n:translate="description_cache_settings" class="documentDescription">
+        <p class="documentDescription"
+           i18n:translate="description_cache_settings"
+        >
                     Control how pages, images, style sheets and other resources are
                     cached.
-                </p>
+        </p>
 
 
-                <form
-                    name="settings"
-                    method="post"
-                    class="enableFormTabbing pat-formunloadalert pat-autotoc"
-                    data-pat-autotoc="levels: legend; section: fieldset; className: autotabs"
-                    tal:attributes="action request/URL"
-                    tal:define="errors view/errors">
+        <form class="enableFormTabbing pat-formunloadalert pat-autotoc"
+              method="post"
+              name="settings"
+              data-pat-autotoc="levels: legend; section: fieldset; className: autotabs"
+              tal:define="
+                errors view/errors;
+              "
+              tal:attributes="
+                action request/URL;
+              "
+        >
 
 
-                    <!-- Field set: global settings -->
-                    <fieldset id="fieldset-global-settings">
-                        <legend
-                            id="fieldsetlegend-global-settings"
-                            i18n:translate="legend_global_settings">Global settings</legend>
+          <!-- Field set: global settings -->
+          <fieldset id="fieldset-global-settings">
+            <legend id="fieldsetlegend-global-settings"
+                    i18n:translate="legend_global_settings"
+            >Global settings</legend>
 
-                        <div
-                            class="form-check"
-                            tal:define="selected python:request.get('enabled', view.settings.enabled)">
+            <div class="form-check"
+                 tal:define="
+                   selected python:request.get('enabled', view.settings.enabled);
+                 "
+            >
 
-                            <input type="hidden" value="" name="enabled:boolean:default" />
-                            <input class="form-check-input"
-                                type="checkbox" value="1" name="enabled:boolean" id="enabled"
-                                tal:attributes="checked python:'checked' if selected else None"
-                                />
-                            <label class="form-check-label"
-                                   for="enabled" i18n:translate="label_enabled">Enable caching</label>
-                            <div class="form-text" i18n:translate="help_enabled">
+              <input name="enabled:boolean:default"
+                     type="hidden"
+                     value=""
+              />
+              <input class="form-check-input"
+                     id="enabled"
+                     name="enabled:boolean"
+                     type="checkbox"
+                     value="1"
+                     tal:attributes="
+                       checked python:'checked' if selected else None;
+                     "
+              />
+              <label class="form-check-label"
+                     for="enabled"
+                     i18n:translate="label_enabled"
+              >Enable caching</label>
+              <div class="form-text"
+                   i18n:translate="help_enabled"
+              >
                                 If this option is disabled, no caching will take place.
-                            </div>
+              </div>
 
-                        </div>
+            </div>
 
-                    </fieldset>
+          </fieldset>
 
-                    <!-- Field set: caching proxies -->
-                    <fieldset id="fieldset-caching-proxies">
-                        <legend
-                            id="fieldsetlegend-caching-proxies"
-                            i18n:translate="legend_caching_proxies">Caching proxies</legend>
+          <!-- Field set: caching proxies -->
+          <fieldset id="fieldset-caching-proxies">
+            <legend id="fieldsetlegend-caching-proxies"
+                    i18n:translate="legend_caching_proxies"
+            >Caching proxies</legend>
 
-                        <div class="discreet" i18n:translate="description_caching_proxies">
+            <div class="discreet"
+                 i18n:translate="description_caching_proxies"
+            >
                             High-performance sites will often place a caching reverse
                             proxy such as Varnish or Squid in front of Zope. The caching
                             operations configured elsewhere on this screen can often take
                             advantage of such a proxy by instructing it to cache certain
                             content in a certain way, whilst passing requests for other
                             content through to Plone always. Plone can also send so-called
-                            <code>PURGE</code> requests to a caching proxy when content
+              <code>PURGE</code>
+               requests to a caching proxy when content
                             changes, reducing the risk of a stale response from a cached
                             copy.
-                        </div>
+            </div>
 
-                        <div class="mb-3 field form-check"
-                            tal:define="selected python:request.get('purgingEnabled', view.purgingSettings.enabled)">
+            <div class="mb-3 field form-check"
+                 tal:define="
+                   selected python:request.get('purgingEnabled', view.purgingSettings.enabled);
+                 "
+            >
 
-                            <input type="hidden" value="" name="purgingEnabled:boolean:default" />
-                            <input class="form-check-input"
-                                   type="checkbox" value="1" name="purgingEnabled:boolean" id="purgingEnabled"
-                                tal:attributes="checked python:'checked' if selected else None"
-                                />
-                            <label class="form-check-label"
-                                   for="purgingEnabled" i18n:translate="label_purging_enabled">Enable purging</label>
-                            <div class="form-text" i18n:translate="help_purging_enabled">
+              <input name="purgingEnabled:boolean:default"
+                     type="hidden"
+                     value=""
+              />
+              <input class="form-check-input"
+                     id="purgingEnabled"
+                     name="purgingEnabled:boolean"
+                     type="checkbox"
+                     value="1"
+                     tal:attributes="
+                       checked python:'checked' if selected else None;
+                     "
+              />
+              <label class="form-check-label"
+                     for="purgingEnabled"
+                     i18n:translate="label_purging_enabled"
+              >Enable purging</label>
+              <div class="form-text"
+                   i18n:translate="help_purging_enabled"
+              >
                                 Enable this option if you have configured a caching proxy
                                 in front of Plone, and the proxy supports HTTP
-                                <code>PURGE</code> requests.
-                            </div>
+                <code>PURGE</code>
+                 requests.
+              </div>
 
-                        </div>
+            </div>
 
-                        <div class="mb-3 field ${python:'error' if error else ''}"
-                             tal:define="error errors/cachingProxies | nothing;
-                                        selected python:request.get('cachingProxies', view.purgingSettings.cachingProxies)"
-                        >
+            <div class="mb-3 field ${python:'error' if error else ''}"
+                 tal:define="
+                   error errors/cachingProxies | nothing;
+                   selected python:request.get('cachingProxies', view.purgingSettings.cachingProxies);
+                 "
+            >
 
-                            <label class="form-label"
-                                   for="cachingProxies" i18n:translate="label_caching_proxies">Caching proxies</label>
+              <label class="form-label"
+                     for="cachingProxies"
+                     i18n:translate="label_caching_proxies"
+              >Caching proxies</label>
 
-                            <div tal:replace="error" tal:condition="error" />
+              <div tal:condition="error"
+                   tal:replace="error"
+              ></div>
 
-                            <textarea class="form-control"
-                                cols="40" rows="4" id="cachingProxies" name="cachingProxies:lines"
-                                tal:content="python:'\n'.join(selected or [])"
-                                ></textarea>
+              <textarea class="form-control"
+                        id="cachingProxies"
+                        cols="40"
+                        name="cachingProxies:lines"
+                        rows="4"
+                        tal:content="python:'\n'.join(selected or [])"
+              ></textarea>
 
-                            <div class="form-text" i18n:translate="help_caching_proxies">
+              <div class="form-text"
+                   i18n:translate="help_caching_proxies"
+              >
                                 Enter the domain name of each caching proxy, one per
                                 line. For example, if you have Varnish running on the
                                 local machine on port 1234, you could enter
-                                <code>http://localhost:1234</code>. The domain name must
+                <code>http://localhost:1234</code>. The domain name must
                                 be reachable by the Zope process, but does not need to
                                 be reachable from users' local machines.
-                            </div>
+              </div>
 
-                        </div>
+            </div>
 
-                        <div class="mb-3 field ${python:'error' if error else ''}"
-                            tal:define="error errors/purgedContentTypes | nothing;
-                                        selected python:request.get('purgedContentTypes', view.ploneSettings.purgedContentTypes)"
-                        >
+            <div class="mb-3 field ${python:'error' if error else ''}"
+                 tal:define="
+                   error errors/purgedContentTypes | nothing;
+                   selected python:request.get('purgedContentTypes', view.ploneSettings.purgedContentTypes);
+                 "
+            >
 
-                            <label class="form-label"
-                                   for="purgedContentTypes" i18n:translate="label_purged_content_types">Content types to purge</label>
+              <label class="form-label"
+                     for="purgedContentTypes"
+                     i18n:translate="label_purged_content_types"
+              >Content types to purge</label>
 
-                            <div tal:replace="error" tal:condition="error" />
+              <div tal:condition="error"
+                   tal:replace="error"
+              ></div>
 
-                            <select class="form-select"
-                                    size="6" multiple="multiple" id="purgedContentTypes" name="purgedContentTypes:list">
-                                <option
-                                    tal:repeat="contentType view/contentTypes"
-                                    tal:attributes="value    contentType/name;
-                                                    title    contentType/description;
-                                                    selected python:'selected' if contentType['name'] in selected else None;"
-                                    tal:content="contentType/title"
-                                    i18n:attributes="title" i18n:translate=""/>
-                            </select>
+              <select class="form-select"
+                      id="purgedContentTypes"
+                      multiple="multiple"
+                      name="purgedContentTypes:list"
+                      size="6"
+              >
+                <option tal:repeat="contentType view/contentTypes"
+                        tal:content="contentType/title"
+                        tal:attributes="
+                          value    contentType/name;
+                          title    contentType/description;
+                          selected python:'selected' if contentType['name'] in selected else None;
+                        "
+                        i18n:attributes="title"
+                        i18n:translate=""
+                ></option>
+              </select>
 
-                            <div class="form-text" i18n:translate="help_purged_content_types">
+              <div class="form-text"
+                   i18n:translate="help_purged_content_types"
+              >
                                 If you have enabled purging, Plone can automatically purge
                                 the views of content items when they are modified or
                                 removed. Select the types to automatically purge below.
-                                <strong>Note:</strong> although a content items's view
+                <strong>Note:</strong>
+                 although a content items's view
                                 can be purged easily, it is not always possible to purge
                                 every page where that item may appear. Items that appear
-                                in dynamic listings (such as <em>Collection</em> portlets),
+                                in dynamic listings (such as
+                <em>Collection</em>
+                 portlets),
                                 the navigation tree and other navigational aids may appear
                                 out of date if you have cached the pages where those
                                 items would appear.
-                            </div>
+              </div>
 
-                        </div>
+            </div>
 
-                        <div class="mb-3 field form-check"
-                            tal:define="selected python:request.get('virtualHosting', view.purgingSettings.virtualHosting)">
+            <div class="mb-3 field form-check"
+                 tal:define="
+                   selected python:request.get('virtualHosting', view.purgingSettings.virtualHosting);
+                 "
+            >
 
-                            <input type="hidden" value="" name="virtualHosting:boolean:default" />
-                            <input class="form-check-input"
-                                   type="checkbox" value="1" name="virtualHosting:boolean" id="virtualHosting"
-                                tal:attributes="checked python:'checked' if selected else None"
-                                />
-                            <label class="form-check-label"
-                                   for="virtualHosting" i18n:translate="label_virtual_hosting">Virtual host rewriting takes place in front of the caching proxy</label>
-                            <div class="form-text" i18n:translate="help_virtual_hosting">
+              <input name="virtualHosting:boolean:default"
+                     type="hidden"
+                     value=""
+              />
+              <input class="form-check-input"
+                     id="virtualHosting"
+                     name="virtualHosting:boolean"
+                     type="checkbox"
+                     value="1"
+                     tal:attributes="
+                       checked python:'checked' if selected else None;
+                     "
+              />
+              <label class="form-check-label"
+                     for="virtualHosting"
+                     i18n:translate="label_virtual_hosting"
+              >Virtual host rewriting takes place in front of the caching proxy</label>
+              <div class="form-text"
+                   i18n:translate="help_virtual_hosting"
+              >
                                 Enable this if you are using virtual hosting with Zope's
                                 VirtualHostMonster and you perform URL rewriting (to
                                 incorporate the special virtual hosting tokens such as
-                                <code>VirtualHostBase</code> and
-                                <code>VirtualHostRoot</code> in the URL) <em>before</em>
+                <code>VirtualHostBase</code>
+                 and
+                <code>VirtualHostRoot</code>
+                in the URL)
+                <em>before</em>
                                 the request is passed to the caching proxy, e.g. in an
                                 Apache web server that receives requests and passes them
                                 on to a Varnish caching proxy. Disable this option if you
                                 are not using virtual hosting, or if the caching proxy is
                                 in front of whatever performs the rewrite (or is itself
                                 performing the rewrites), disable this option.
-                            </div>
+              </div>
 
-                        </div>
+            </div>
 
-                        <div class="mb-3 field ${python:'error' if error else ''}"
-                            tal:define="error errors/domains | nothing;
-                                        selected python:request.get('domains', view.purgingSettings.domains)"
-                        >
+            <div class="mb-3 field ${python:'error' if error else ''}"
+                 tal:define="
+                   error errors/domains | nothing;
+                   selected python:request.get('domains', view.purgingSettings.domains);
+                 "
+            >
 
-                            <label class="form-label"
-                                   for="domains" i18n:translate="label_domains">Externally facing domains</label>
+              <label class="form-label"
+                     for="domains"
+                     i18n:translate="label_domains"
+              >Externally facing domains</label>
 
-                            <div tal:replace="error" tal:condition="error" />
+              <div tal:condition="error"
+                   tal:replace="error"
+              ></div>
 
-                            <textarea class="form-control"
-                                cols="40" rows="4" id="domains" name="domains:lines"
-                                tal:content="python:'\n'.join(selected or [])"
-                                ></textarea>
+              <textarea class="form-control"
+                        id="domains"
+                        cols="40"
+                        name="domains:lines"
+                        rows="4"
+                        tal:content="python:'\n'.join(selected or [])"
+              ></textarea>
 
-                            <div class="form-text" i18n:translate="help_domains">
-                                <p>
-                                If you have enabled <em>Virtual host rewriting takes place
-                                front of the caching proxy</em> above, and your site is
+              <div class="form-text"
+                   i18n:translate="help_domains"
+              >
+                <p>
+                                If you have enabled
+                  <em>Virtual host rewriting takes place
+                    front of the caching proxy</em>
+                   above, and your site is
                                 reachable via multiple domains (e.g.
-                                <code>http://example.com:80</code> vs.
-                                <code>http://www.example.com:80</code>), enter all available
+                  <code>http://example.com:80</code>
+                   vs.
+                  <code>http://www.example.com:80</code>), enter all available
                                 domains here, one per line. This will ensure that purge
                                 requests are sent for all domains where applicable. Note
                                 that it is more efficient to configure the front-most web
                                 server to simply redirect all requests to a single domain,
                                 so that Zope only "sees" a single domain.
-                                </p>
-                                <p>
+                </p>
+                <p>
                                 It is safe to leave this list blank if you are not using
                                 a caching proxy, if you are not using virtual hosting,
                                 if virtual host rewriting takes place behind the caching
                                 proxy, or if you only have a single virtually hosted
                                 domain name.
-                                </p>
-                            </div>
+                </p>
+              </div>
 
-                        </div>
+            </div>
 
-                    </fieldset>
+          </fieldset>
 
-                    <!-- Field set: memory -->
-                    <fieldset id="fieldset-ram">
-                        <legend
-                            id="fieldsetlegend-ram"
-                            i18n:translate="legend_ram">In-memory cache</legend>
+          <!-- Field set: memory -->
+          <fieldset id="fieldset-ram">
+            <legend id="fieldsetlegend-ram"
+                    i18n:translate="legend_ram"
+            >In-memory cache</legend>
 
-                        <div class="discreet" i18n:translate="description_ram">
+            <div class="discreet"
+                 i18n:translate="description_ram"
+            >
                             Plone maintains a cache of certain pages and
                             fragments of pages in memory to speed up
                             rendering. Certain caching operations, when
@@ -314,254 +437,364 @@
                             load balancer so that they always reach the same
                             back-end instance. As an alternative, you can
                             integrate a shared cache such as
-                            <em>memcached</em>. See the documentation for
+              <em>memcached</em>. See the documentation for
                             details.
-                        </div>
+            </div>
 
-                        <div class="mb-3 field ${python:'error' if error else ''}"
-                            tal:define="error errors/ramCacheMaxEntries | nothing"
-                        >
+            <div class="mb-3 field ${python:'error' if error else ''}"
+                 tal:define="
+                   error errors/ramCacheMaxEntries | nothing;
+                 "
+            >
 
-                            <label class="form-label"
-                                for="ramCacheMaxEntries"
-                                i18n:translate="label_ram_max_entries">Maximum entries in the cache</label>
+              <label class="form-label"
+                     for="ramCacheMaxEntries"
+                     i18n:translate="label_ram_max_entries"
+              >Maximum entries in the cache</label>
 
-                            <span class="fieldRequired" i18n:translate="">(Required)</span>
+              <span class="fieldRequired"
+                    i18n:translate=""
+              >(Required)</span>
 
-                            <div tal:condition="error" tal:content="error" />
+              <div tal:condition="error"
+                   tal:content="error"
+              ></div>
 
-                            <input class="form-control"
-                                name="ramCacheMaxEntries" id="ramCacheMaxEntries" size="6"
-                                tal:attributes="value request/ramCacheMaxEntries | view/ramCache/maxEntries | nothing" />
+              <input class="form-control"
+                     id="ramCacheMaxEntries"
+                     name="ramCacheMaxEntries"
+                     size="6"
+                     tal:attributes="
+                       value request/ramCacheMaxEntries | view/ramCache/maxEntries | nothing;
+                     "
+              />
 
-                            <div class="form-text" i18n:translate="help_ram_max_entries">
+              <div class="form-text"
+                   i18n:translate="help_ram_max_entries"
+              >
                                 Use this to control how many items can be
                                 placed in the cache. The more items you allow,
                                 the higher the potential memory consumption.
-                            </div>
+              </div>
 
-                        </div>
+            </div>
 
-                        <div class="mb-3 field ${python:'error' if error else ''}"
-                            tal:define="error errors/ramCacheMaxAge | nothing"
-                        >
+            <div class="mb-3 field ${python:'error' if error else ''}"
+                 tal:define="
+                   error errors/ramCacheMaxAge | nothing;
+                 "
+            >
 
-                            <label
-                                for="ramCacheMaxAge"
-                                i18n:translate="label_ram_max_age">Maximum age of entries in the cache</label>
+              <label for="ramCacheMaxAge"
+                     i18n:translate="label_ram_max_age"
+              >Maximum age of entries in the cache</label>
 
-                            <span class="fieldRequired" i18n:translate="">(Required)</span>
+              <span class="fieldRequired"
+                    i18n:translate=""
+              >(Required)</span>
 
-                            <div tal:condition="error" tal:content="error" />
+              <div tal:condition="error"
+                   tal:content="error"
+              ></div>
 
-                            <input class="form-control"
-                                name="ramCacheMaxAge" id="ramCacheMaxAge" size="6"
-                                tal:attributes="value request/ramCacheMaxAge | view/ramCache/maxAge | nothing" />
+              <input class="form-control"
+                     id="ramCacheMaxAge"
+                     name="ramCacheMaxAge"
+                     size="6"
+                     tal:attributes="
+                       value request/ramCacheMaxAge | view/ramCache/maxAge | nothing;
+                     "
+              />
 
-                            <div class="form-text" i18n:translate="help_ram_max_age">
+              <div class="form-text"
+                   i18n:translate="help_ram_max_age"
+              >
                                 Enter the maximum time, in seconds, that an item
                                 may remain in the cache before being purged.
-                            </div>
+              </div>
 
-                        </div>
+            </div>
 
-                        <div class="mb-3 field ${python:'error' if error else ''}"
-                            tal:define="error errors/ramCacheCleanupInterval | nothing"
-                        >
+            <div class="mb-3 field ${python:'error' if error else ''}"
+                 tal:define="
+                   error errors/ramCacheCleanupInterval | nothing;
+                 "
+            >
 
-                            <label
-                                for="ramCacheCleanupInterval"
-                                i18n:translate="label_ram_cleanup_interval">Cleanup interval</label>
+              <label for="ramCacheCleanupInterval"
+                     i18n:translate="label_ram_cleanup_interval"
+              >Cleanup interval</label>
 
-                            <span class="fieldRequired" i18n:translate="">(Required)</span>
+              <span class="fieldRequired"
+                    i18n:translate=""
+              >(Required)</span>
 
-                            <div tal:condition="error" tal:content="error" />
+              <div tal:condition="error"
+                   tal:content="error"
+              ></div>
 
-                            <input class="form-control"
-                                name="ramCacheCleanupInterval" id="ramCacheCleanupInterval" size="6"
-                                tal:attributes="value request/ramCacheCleanupInterval | view/ramCache/cleanupInterval | nothing" />
+              <input class="form-control"
+                     id="ramCacheCleanupInterval"
+                     name="ramCacheCleanupInterval"
+                     size="6"
+                     tal:attributes="
+                       value request/ramCacheCleanupInterval | view/ramCache/cleanupInterval | nothing;
+                     "
+              />
 
-                            <div class="form-text" i18n:translate="help_ram_cleanup_interval">
+              <div class="form-text"
+                   i18n:translate="help_ram_cleanup_interval"
+              >
                                 Enter the time, in seconds, before attempts
                                 to clean up the cache. A lower value may reduce
                                 memory consumption by purging items frequently,
                                 but can also slow down the system by tying up
                                 the cache with maintenance tasks for too long.
-                            </div>
+              </div>
 
-                        </div>
+            </div>
 
-                    </fieldset>
+          </fieldset>
 
-                    <!-- Field set: mappings -->
-                    <fieldset id="fieldset-mappings">
-                        <legend
-                            id="fieldsetlegend-mappings"
-                            i18n:translate="legend_mappings">Caching operations</legend>
+          <!-- Field set: mappings -->
+          <fieldset id="fieldset-mappings">
+            <legend id="fieldsetlegend-mappings"
+                    i18n:translate="legend_mappings"
+            >Caching operations</legend>
 
-                        <div class="discreet" i18n:translate="description_mappings">
-                            <p>
-                            Caching can be controlled by mapping <em>rulesets</em> to
-                            <em>caching operations</em>.
-                            </p>
-                            <p>
-                            A <strong>ruleset</strong> is a name given to a resource
+            <div class="discreet"
+                 i18n:translate="description_mappings"
+            >
+              <p>
+                            Caching can be controlled by mapping
+                <em>rulesets</em>
+                 to
+                <em>caching operations</em>.
+              </p>
+              <p>
+                            A
+                <strong>ruleset</strong>
+                 is a name given to a resource
                             published by Plone, such as a view. Rulesets are declared by
                             the developers who write those views. You can think of them as
                             a way to give hints about how something should be cached,
                             without actually implementing the caching operations.
-                            </p>
-                            <p>
+              </p>
+              <p>
                             The exact caching operations to use are mapped to
                             rulesets in the table below. Caching operations will often
                             set response headers to tell the users's web browser and/or
                             a caching proxy how to cache content. They may also intercept
                             a response to return a cached copy or instruct the browser to use
                             its own cached copy, if it is considered to be current.
-                            </p>
-                        </div>
-                        <div class="mb-3 field">
-                            <label i18n:translate="label_mappings">Ruleset mappings</label>
-                            <div class="form-text" i18n:translate="help_main_mappings">
+              </p>
+            </div>
+            <div class="mb-3 field">
+              <label i18n:translate="label_mappings">Ruleset mappings</label>
+              <div class="form-text"
+                   i18n:translate="help_main_mappings"
+              >
                                 Use the table below to map rulesets to caching
                                 operations.
-                            </div>
+              </div>
 
-                            <table class="table table-striped table-responsive" id="rulesetMappingsTable">
-                                <thead>
-                                    <tr>
-                                        <th class="col-9"
-                                            i18n:translate="heading_ruleset">Ruleset</th>
-                                        <th class="col-3"
-                                            i18n:translate="heading_operation">Operation</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <tr tal:repeat="ruleType view/ruleTypes">
-                                        <td>
-                                            <label class="form-label"
-                                                tal:content="ruleType/title" i18n:translate=""/>
-                                            <p class="form-text" tal:content="ruleType/description" i18n:translate=""/>
-                                        </td>
-                                        <td tal:define="selected python:request.get('operations', view.operationMapping).get(ruleType['safeName'], None)">
-                                            <select class="form-select"
-                                                size="1"
-                                                tal:attributes="id   string:operation-${ruleType/name};
-                                                                name string:operations.${ruleType/safeName}:record;">
-                                                <option
-                                                    value=""
-                                                    tal:attributes="selected python:'selected' if selected is None else None"
-                                                    i18n:translate="value_not_used"
-                                                    >(Not used)</option>
-                                                <option
-                                                    tal:repeat="operationType view/operationTypes"
-                                                    tal:attributes="value    operationType/name;
-                                                                    title    operationType/description;
-                                                                    selected python:'selected' if operationType['name'] == selected else None;"
-                                                    tal:content="operationType/title"
-                                                    />
-                                            </select>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
+              <table class="table table-striped table-responsive"
+                     id="rulesetMappingsTable"
+              >
+                <thead>
+                  <tr>
+                    <th class="col-9"
+                        i18n:translate="heading_ruleset"
+                    >Ruleset</th>
+                    <th class="col-3"
+                        i18n:translate="heading_operation"
+                    >Operation</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr tal:repeat="ruleType view/ruleTypes">
+                    <td>
+                      <label class="form-label"
+                             tal:content="ruleType/title"
+                             i18n:translate=""
+                      ></label>
+                      <p class="form-text"
+                         tal:content="ruleType/description"
+                         i18n:translate=""
+                      ></p>
+                    </td>
+                    <td tal:define="
+                          selected python:request.get('operations', view.operationMapping).get(ruleType['safeName'], None);
+                        ">
+                      <select class="form-select"
+                              size="1"
+                              tal:attributes="
+                                id   string:operation-${ruleType/name};
+                                name string:operations.${ruleType/safeName}:record;
+                              "
+                      >
+                        <option value=""
+                                tal:attributes="
+                                  selected python:'selected' if selected is None else None;
+                                "
+                                i18n:translate="value_not_used"
+                        >(Not used)</option>
+                        <option tal:repeat="operationType view/operationTypes"
+                                tal:content="operationType/title"
+                                tal:attributes="
+                                  value    operationType/name;
+                                  title    operationType/description;
+                                  selected python:'selected' if operationType['name'] == selected else None;
+                                "
+                        ></option>
+                      </select>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
 
-                        <div class="mb-3 field">
-                            <label class="form-label"
-                                i18n:translate="label_template_mappings">Legacy template mappings</label>
-                            <div class="form-text" i18n:translate="help_template_mappings">
-                                <p>
-                                Legacy page templates defined in the <em>portal_skins</em>
+            <div class="mb-3 field">
+              <label class="form-label"
+                     i18n:translate="label_template_mappings"
+              >Legacy template mappings</label>
+              <div class="form-text"
+                   i18n:translate="help_template_mappings"
+              >
+                <p>
+                                Legacy page templates defined in the
+                  <em>portal_skins</em>
                                 tool in the ZMI, or created or customised through the web cannot be
                                 associated with rulesets in the usual way. There are two options:
-                                </p>
-                                <ul>
-                                    <li>If the template is the <em>default type</em> of a content type
+                </p>
+                <ul>
+                  <li>If the template is the
+                    <em>default type</em>
+                     of a content type
                                         it is possible to associate the type class or an interface it
-                                        provides with a ruleset.</li>
-                                    <li>You can also associate a specific page template (by name) or
-                                        content type with a ruleset using the options below.</li>
-                                </ul>
-                                <p>
-                                <strong>Note:</strong> By default, folder-like content types are
-                                associated with the ruleset <code>plone.content.folderView</code>,
+                    provides with a ruleset.</li>
+                  <li>You can also associate a specific page template (by name) or
+                    content type with a ruleset using the options below.</li>
+                </ul>
+                <p>
+                  <strong>Note:</strong>
+                   By default, folder-like content types are
+                                associated with the ruleset
+                  <code>plone.content.folderView</code>,
                                 and item-like content types are associated with the ruleset
-                                <code>plone.content.itemView</code>. Any settings entered below or
+                  <code>plone.content.itemView</code>. Any settings entered below or
                                 set via an explicit cache ruleset (in a ZCML file) will override these
                                 defaults.
-                                </p>
-                                <p>
-                                <strong>Note:</strong> You can only use each template name or
+                </p>
+                <p>
+                  <strong>Note:</strong>
+                   You can only use each template name or
                                 content type once!
-                                </p>
-                            </div>
+                </p>
+              </div>
 
-                            <table class="table table-striped table-responsive" id="templateMappingsTable">
-                                <thead>
-                                    <tr>
-                                        <th class="col-6"
-                                            i18n:translate="heading_ruleset">Ruleset</th>
-                                        <th class="col-3"
-                                            i18n:translate="heading_content_types">Content types</th>
-                                        <th class="col-3"
-                                            i18n:translate="heading_templates">Templates</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <tal:block repeat="ruleType view/ruleTypes">
-                                        <tr tal:define="contentTypeError python:errors.get('contenttypes', {}).get(ruleType['name'], None);
-                                                        templateError    python:errors.get('templates', {}).get(ruleType['name'], None);">
-                                            <td>
-                                                <div tal:content="ruleType/title" i18n:translate=""/>
-                                                <p class="discreet" tal:content="ruleType/description" i18n:translate=""/>
-                                                <div class="invalid-feedback" tal:condition="python:contentTypeError or templateError">
-                                                    <div tal:content="contentTypeError" tal:condition="contentTypeError" />
-                                                    <div tal:content="templateError" tal:condition="templateError" />
-                                                </div>
-                                            </td>
-                                            <td tal:define="selected python:request.get('contenttypes', view.reverseContentTypeMapping).get(ruleType['safeName'], [])">
-                                                <div class="invalid-feedback" tal:omit-tag="not:contentTypeError">
-                                                    <select class="form-select"
-                                                        size="6"
-                                                        multiple="multiple"
-                                                        tal:attributes="id   string:contenttypes-${ruleType/name};
-                                                                        name string:contenttypes.${ruleType/safeName}:record:list;">
-                                                        <option
-                                                            tal:repeat="contentType view/contentTypes"
-                                                            tal:attributes="value    contentType/name;
-                                                                            title    contentType/description;
-                                                                            selected python:'selected' if contentType['name'] in selected else None;"
-                                                            tal:content="contentType/title"
-                                                            i18n:attributes="title" i18n:translate="" />
-                                                    </select>
-                                                </div>
-                                            </td>
-                                            <td tal:define="selected python:request.get('templates', view.reverseTemplateMapping).get(ruleType['safeName'], '')">
-                                                <div class="invalid-feedback" tal:omit-tag="not:templateError">
-                                                    <textarea class="form-control"
-                                                        cols="40" rows="4"
-                                                        tal:attributes="id   string:templates-${ruleType/name};
-                                                                        name string:templates.${ruleType/safeName}:record:lines"
-                                                        tal:content="python:'\n'.join(selected or [])"
-                                                        ></textarea>
-                                                </div>
-                                            </td>
-                                        </tr>
-                                    </tal:block>
-                                </tbody>
-                            </table>
+              <table class="table table-striped table-responsive"
+                     id="templateMappingsTable"
+              >
+                <thead>
+                  <tr>
+                    <th class="col-6"
+                        i18n:translate="heading_ruleset"
+                    >Ruleset</th>
+                    <th class="col-3"
+                        i18n:translate="heading_content_types"
+                    >Content types</th>
+                    <th class="col-3"
+                        i18n:translate="heading_templates"
+                    >Templates</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tal:block repeat="ruleType view/ruleTypes">
+                    <tr tal:define="
+                          contentTypeError python:errors.get('contenttypes', {}).get(ruleType['name'], None);
+                          templateError    python:errors.get('templates', {}).get(ruleType['name'], None);
+                        ">
+                      <td>
+                        <div tal:content="ruleType/title"
+                             i18n:translate=""
+                        ></div>
+                        <p class="discreet"
+                           tal:content="ruleType/description"
+                           i18n:translate=""
+                        ></p>
+                        <div class="invalid-feedback"
+                             tal:condition="python:contentTypeError or templateError"
+                        >
+                          <div tal:condition="contentTypeError"
+                               tal:content="contentTypeError"
+                          ></div>
+                          <div tal:condition="templateError"
+                               tal:content="templateError"
+                          ></div>
                         </div>
-                    </fieldset>
+                      </td>
+                      <td tal:define="
+                            selected python:request.get('contenttypes', view.reverseContentTypeMapping).get(ruleType['safeName'], []);
+                          ">
+                        <div class="invalid-feedback"
+                             tal:omit-tag="not:contentTypeError"
+                        >
+                          <select class="form-select"
+                                  multiple="multiple"
+                                  size="6"
+                                  tal:attributes="
+                                    id   string:contenttypes-${ruleType/name};
+                                    name string:contenttypes.${ruleType/safeName}:record:list;
+                                  "
+                          >
+                            <option tal:repeat="contentType view/contentTypes"
+                                    tal:content="contentType/title"
+                                    tal:attributes="
+                                      value    contentType/name;
+                                      title    contentType/description;
+                                      selected python:'selected' if contentType['name'] in selected else None;
+                                    "
+                                    i18n:attributes="title"
+                                    i18n:translate=""
+                            ></option>
+                          </select>
+                        </div>
+                      </td>
+                      <td tal:define="
+                            selected python:request.get('templates', view.reverseTemplateMapping).get(ruleType['safeName'], '');
+                          ">
+                        <div class="invalid-feedback"
+                             tal:omit-tag="not:templateError"
+                        >
+                          <textarea class="form-control"
+                                    cols="40"
+                                    rows="4"
+                                    tal:content="python:'\n'.join(selected or [])"
+                                    tal:attributes="
+                                      id   string:templates-${ruleType/name};
+                                      name string:templates.${ruleType/safeName}:record:lines;
+                                    "
+                          ></textarea>
+                        </div>
+                      </td>
+                    </tr>
+                  </tal:block>
+                </tbody>
+              </table>
+            </div>
+          </fieldset>
 
-                    <!-- Field set: detailed settings -->
-                    <fieldset id="fieldset-detailed-settings">
-                        <legend
-                            id="fieldsetlegend-detailed-settings"
-                            i18n:translate="legend_detailed_settings">Detailed settings</legend>
+          <!-- Field set: detailed settings -->
+          <fieldset id="fieldset-detailed-settings">
+            <legend id="fieldsetlegend-detailed-settings"
+                    i18n:translate="legend_detailed_settings"
+            >Detailed settings</legend>
 
-                        <div class="discreet" i18n:translate="description_detailed_settings">
-                            <p>
+            <div class="discreet"
+                 i18n:translate="description_detailed_settings"
+            >
+              <p>
                             Many caching operations accept parameters to influence their
                             behaviour. For example, an operation which returns a page
                             cached in RAM may accept a parameter specifying the timeout
@@ -569,128 +802,160 @@
                             however, will have "sensible defaults", so that  they work
                             acceptably even when no parameters have been set. Note also
                             that not all operations support parameters.
-                            </p>
-                            <p>
+              </p>
+              <p>
                             Parameters can be set at two levels. By default, parameters
                             apply to all uses of particular operation. Thus, if you have
                             assigned an operation to more than one ruleset, the
-                            <em>same</em> parameters will be used. However, you can also
+                <em>same</em>
+                 parameters will be used. However, you can also
                             override the parameters for a particular ruleset.
-                            </p>
-                            <p>
+              </p>
+              <p>
                             Use the table below to access parameters for a particular
-                            operation or ruleset. <strong>Warning:</strong> If you have
+                            operation or ruleset.
+                <strong>Warning:</strong>
+                 If you have
                             made changes elsewhere in this form, you should save them
                             before configuring any operation parameters. Otherwise, you
                             will lose your changes.
-                            </p>
-                        </div>
-                        <div class="mb-3 field">
-                            <label class="form-label"
-                                   i18n:translate="label_operation_parameters">Operation parameters</label>
-                            <div class="form-text" i18n:translate="help_operation_parameters">
+              </p>
+            </div>
+            <div class="mb-3 field">
+              <label class="form-label"
+                     i18n:translate="label_operation_parameters"
+              >Operation parameters</label>
+              <div class="form-text"
+                   i18n:translate="help_operation_parameters"
+              >
                                 Use the table below to create, clear and edit operation
                                 parameters. If you clear the ruleset-specific parameters for
                                 a given operation, it will fall back on the global operation
                                 parameters.
-                            </div>
+              </div>
 
-                            <table class="table table-striped table-responsive" id="operationParametersTable">
-                                <thead>
-                                    <tr>
-                                        <th class="col-9"
-                                            i18n:translate="heading_ruleset">Ruleset</th>
-                                        <th class="col-3"
-                                            i18n:translate="heading_operation">Operation</th>
-                                    </tr>
-                                </thead>
-                                <tbody>
-                                    <tr tal:repeat="ruleType view/ruleTypes">
-                                        <td>
-                                            <div class="form-label"
-                                                 tal:content="ruleType/title" i18n:translate=""/>
-                                            <p class="form-text"
-                                               tal:content="ruleType/description" i18n:translate=""/>
-                                        </td>
-                                        <td tal:define="operationName python:view.operationMapping.get(ruleType['safeName'], None)">
-                                            <tal:block condition="not:operationName" i18n:translate="help_not_mapped">
+              <table class="table table-striped table-responsive"
+                     id="operationParametersTable"
+              >
+                <thead>
+                  <tr>
+                    <th class="col-9"
+                        i18n:translate="heading_ruleset"
+                    >Ruleset</th>
+                    <th class="col-3"
+                        i18n:translate="heading_operation"
+                    >Operation</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr tal:repeat="ruleType view/ruleTypes">
+                    <td>
+                      <div class="form-label"
+                           tal:content="ruleType/title"
+                           i18n:translate=""
+                      ></div>
+                      <p class="form-text"
+                         tal:content="ruleType/description"
+                         i18n:translate=""
+                      ></p>
+                    </td>
+                    <td tal:define="
+                          operationName python:view.operationMapping.get(ruleType['safeName'], None);
+                        ">
+                      <tal:block condition="not:operationName"
+                                 i18n:translate="help_not_mapped"
+                      >
                                                 Not mapped
-                                            </tal:block>
-                                            <tal:block condition="operationName">
-                                                <tal:block
-                                                    define="operationInfo python:view.operationTypesLookup.get(operationName, None)"
-                                                    condition="operationInfo">
-                                                    <div tal:content="operationInfo/title" />
-                                                    <div
-                                                        class="discreet"
-                                                        tal:condition="not:operationInfo/hasOptions"
-                                                        i18n:translate="help_no_options">
+                      </tal:block>
+                      <tal:block condition="operationName">
+                        <tal:block define="
+                                     operationInfo python:view.operationTypesLookup.get(operationName, None);
+                                   "
+                                   condition="operationInfo"
+                        >
+                          <div tal:content="operationInfo/title"></div>
+                          <div class="discreet"
+                               tal:condition="not:operationInfo/hasOptions"
+                               i18n:translate="help_no_options"
+                          >
                                                         No parameters
-                                                    </div>
-                                                    <div style="white-space: nowrap" class="discreet rulesetParameterLink" tal:condition="operationInfo/hasOptions">
-                                                        <a  class="editGlobalOperationParameters pat-plone-modal"
-                                                            data-pat-plone-modal="{'actionOptions': {'disableAjaxFormSubmit':true}}"
-                                                            i18n:translate="link_view_edit"
-                                                            tal:attributes="href string:${context/absolute_url}/@@${view/__name__}/edit-operation-global/${operationName}"
-                                                            >View/edit</a>
-                                                        <span i18n:translate="label_global">global parameters</span>
-                                                    </div>
-                                                    <div style="white-space: nowrap" class="discreet rulesetParameterLink"  tal:condition="operationInfo/hasOptions">
-                                                        <tal:block define="hasRulesetOptions python:view.hasRulesetOptions(operationInfo['type'], ruleType['name'])">
-                                                            <a  class="editRulesetOperationParameters pat-plone-modal"
-                                                                data-pat-plone-modal="{'actionOptions': {'disableAjaxFormSubmit':true}}"
-                                                                tal:condition="hasRulesetOptions"
-                                                                i18n:translate="link_view_edit_clear"
-                                                                tal:attributes="href string:${context/absolute_url}/@@${view/__name__}/edit-operation-ruleset/${operationName}/${ruleType/name}"
-                                                                >View/edit/clear</a>
-                                                            <a  class="editRulesetOperationParameters pat-plone-modal"
-                                                                data-pat-plone-modal="{'actionOptions': {'disableAjaxFormSubmit':true}}"
-                                                                tal:condition="not:hasRulesetOptions"
-                                                                i18n:translate="link_create"
-                                                                tal:attributes="href string:${context/absolute_url}/@@${view/__name__}/edit-operation-ruleset/${operationName}/${ruleType/name}"
-                                                                >Create</a>
-                                                        </tal:block>
-                                                        <span i18n:translate="label_ruleset">per-ruleset parameters</span>
-                                                    </div>
-                                                </tal:block>
-                                            </tal:block>
-                                        </td>
-                                    </tr>
-                                </tbody>
-                            </table>
-                        </div>
-
-                    </fieldset>
-
-                    <div class="formControls">
-                        <button
-                            type="submit"
-                            name="form.button.Save"
-                            class="btn btn-primary"
-                            value="Save"
-                            i18n:attributes="value"
-                            i18n:translate=""
-                        >
-                            Save
-                        </button>
-
-                        <button
-                            type="submit"
-                            name="form.button.Cancel"
-                            class="btn btn-secondary"
-                            value="Cancel"
-                            i18n:attributes="value"
-                            i18n:translate=""
-                        >
-                            Cancel
-                        </button>
-
-                    </div>
-
-                    <input tal:replace="structure context/@@authenticator/authenticator" />
-
-                </form>
+                          </div>
+                          <div class="discreet rulesetParameterLink"
+                               style="white-space: nowrap"
+                               tal:condition="operationInfo/hasOptions"
+                          >
+                            <a class="editGlobalOperationParameters pat-plone-modal"
+                               data-pat-plone-modal="{'actionOptions': {'disableAjaxFormSubmit':true}}"
+                               tal:attributes="
+                                 href string:${context/absolute_url}/@@${view/__name__}/edit-operation-global/${operationName};
+                               "
+                               i18n:translate="link_view_edit"
+                            >View/edit</a>
+                            <span i18n:translate="label_global">global parameters</span>
+                          </div>
+                          <div class="discreet rulesetParameterLink"
+                               style="white-space: nowrap"
+                               tal:condition="operationInfo/hasOptions"
+                          >
+                            <tal:block define="
+                                         hasRulesetOptions python:view.hasRulesetOptions(operationInfo['type'], ruleType['name']);
+                                       ">
+                              <a class="editRulesetOperationParameters pat-plone-modal"
+                                 data-pat-plone-modal="{'actionOptions': {'disableAjaxFormSubmit':true}}"
+                                 tal:condition="hasRulesetOptions"
+                                 tal:attributes="
+                                   href string:${context/absolute_url}/@@${view/__name__}/edit-operation-ruleset/${operationName}/${ruleType/name};
+                                 "
+                                 i18n:translate="link_view_edit_clear"
+                              >View/edit/clear</a>
+                              <a class="editRulesetOperationParameters pat-plone-modal"
+                                 data-pat-plone-modal="{'actionOptions': {'disableAjaxFormSubmit':true}}"
+                                 tal:condition="not:hasRulesetOptions"
+                                 tal:attributes="
+                                   href string:${context/absolute_url}/@@${view/__name__}/edit-operation-ruleset/${operationName}/${ruleType/name};
+                                 "
+                                 i18n:translate="link_create"
+                              >Create</a>
+                            </tal:block>
+                            <span i18n:translate="label_ruleset">per-ruleset parameters</span>
+                          </div>
+                        </tal:block>
+                      </tal:block>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
             </div>
-        </div>
-</body>
+
+          </fieldset>
+
+          <div class="formControls">
+            <button class="btn btn-primary"
+                    name="form.button.Save"
+                    type="submit"
+                    value="Save"
+                    i18n:attributes="value"
+                    i18n:translate=""
+            >
+                            Save
+            </button>
+
+            <button class="btn btn-secondary"
+                    name="form.button.Cancel"
+                    type="submit"
+                    value="Cancel"
+                    i18n:attributes="value"
+                    i18n:translate=""
+            >
+                            Cancel
+            </button>
+
+          </div>
+
+          <input tal:replace="structure context/@@authenticator/authenticator" />
+
+        </form>
+      </div>
+    </div>
+  </body>
 </html>

--- a/plone/app/caching/browser/controlpanel.py
+++ b/plone/app/caching/browser/controlpanel.py
@@ -110,7 +110,6 @@ class ControlPanel(BaseView):
             self.editOperationName = name
 
             if self.editGlobal:
-
                 operation = queryUtility(
                     ICachingOperationType, name=self.editOperationName
                 )
@@ -163,7 +162,6 @@ class ControlPanel(BaseView):
                 )
 
     def processSave(self):
-
         form = self.request.form
 
         # Form data
@@ -215,7 +213,10 @@ class ControlPanel(BaseView):
                         contentType,
                     )
                     error_ruleset = contentTypeRulesetMapping[contentType]
-                    self.errors.setdefault("contenttypes", {},)[ruleset] = _(
+                    self.errors.setdefault(
+                        "contenttypes",
+                        {},
+                    )[ruleset] = _(
                         "Content type ${error_content_type} is already mapped to "
                         "the rule ${ruleset}.",
                         mapping={
@@ -237,7 +238,10 @@ class ControlPanel(BaseView):
                     continue
 
                 if template in templateRulesetMapping:
-                    self.errors.setdefault("templates", {},)[ruleset] = _(
+                    self.errors.setdefault(
+                        "templates",
+                        {},
+                    )[ruleset] = _(
                         "Template ${template} is already mapped to the rule "
                         "${ruleset}.",
                         mapping={
@@ -630,7 +634,6 @@ class RAMCache(BaseView):
                 self.processPurge()
 
     def processPurge(self):
-
         if self.ramCache is None:
             IStatusMessage(self.request).addStatusMessage(
                 _("RAM cache not installed."), "error"

--- a/plone/app/caching/browser/edit.pt
+++ b/plone/app/caching/browser/edit.pt
@@ -1,20 +1,24 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
-      xmlns:tal="http://xml.zope.org/namespaces/tal"
-      xmlns:metal="http://xml.zope.org/namespaces/metal"
+<html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
       lang="en"
       metal:use-macro="context/prefs_main_template/macros/master"
-      i18n:domain="plone">
+      xml:lang="en"
+      i18n:domain="plone"
+>
 
-<body>
-<metal:block fill-slot="prefs_configlet_main">
+  <body>
+    <metal:block fill-slot="prefs_configlet_main">
 
-    <h1 class="documentFirstHeading" tal:content="view/title">View Title</h1>
+      <h1 class="documentFirstHeading"
+          tal:content="view/title"
+      >View Title</h1>
 
-    <div id="content-core">
+      <div id="content-core">
         <metal:block use-macro="context/@@ploneform-macros/titlelessform" />
-    </div>
+      </div>
 
-</metal:block>
-</body>
+    </metal:block>
+  </body>
 </html>

--- a/plone/app/caching/browser/edit.py
+++ b/plone/app/caching/browser/edit.py
@@ -75,7 +75,6 @@ class EditForm(form.Form):
         self.ruleset = ruleset
 
     def update(self):
-
         self.registry = getUtility(IRegistry)
 
         # If we were using plone.z3cform, this would be done with
@@ -170,10 +169,8 @@ class EditForm(form.Form):
         """Save changes in the given data dictionary to the registry."""
 
         for key, value in data.items():
-
             # Lazily create per-ruleset records if necessary
             if key not in self.registry.records:
-
                 # This should only ever happen if we have a not-yet-creted
                 # ruleset-specific record
                 assert self.rulesetName in key
@@ -195,7 +192,6 @@ class EditForm(form.Form):
                 self.registry[key] = value
 
     def cloneField(self, field):
-
         # XXX: The field may sometimes not have data for reasons known only
         # to Jim.
         try:

--- a/plone/app/caching/browser/import.pt
+++ b/plone/app/caching/browser/import.pt
@@ -1,136 +1,181 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
-      xmlns:tal="http://xml.zope.org/namespaces/tal"
-      xmlns:metal="http://xml.zope.org/namespaces/metal"
+<html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    lang="en"
-    metal:use-macro="context/prefs_main_template/macros/master"
-    i18n:domain="plone">
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      lang="en"
+      metal:use-macro="context/prefs_main_template/macros/master"
+      xml:lang="en"
+      i18n:domain="plone"
+>
 
-<body>
+  <body>
 
-<div metal:fill-slot="prefs_configlet_main">
+    <div metal:fill-slot="prefs_configlet_main">
 
-            <div class="autotabs">
-                <ul class="nav nav-tabs">
-                    <li class="nav-item">
-                        <a class="nav-link"
-                           href=""
-                           tal:attributes="href string:${portal_url}/@@caching-controlpanel"
-                           i18n:translate="label_settings">Change settings</a>
-                      </li>
-                      <li class="nav-item">
-                        <a class="nav-link active"
-                           href=""
-                           tal:attributes="href string:${portal_url}/@@caching-controlpanel-import"
-                           i18n:translate="label_import">Import settings</a>
-                      </li>
-                      <li tal:condition="view/purgingEnabled" class="nav-item">
-                        <a class="nav-link"
-                           href=""
-                           tal:attributes="href string:${portal_url}/@@caching-controlpanel-purge"
-                           i18n:translate="label_purging">Purge caching proxy</a>
-                      </li>
-                      <li class="nav-item">
-                        <a class="nav-link"
-                           href=""
-                           tal:attributes="href string:${portal_url}/@@caching-controlpanel-ramcache"
-                           i18n:translate="label_ramcache">RAM cache</a>
-                      </li>
-                </ul>
-            </div>
+      <div class="autotabs">
+        <ul class="nav nav-tabs">
+          <li class="nav-item">
+            <a class="nav-link"
+               href=""
+               tal:attributes="
+                 href string:${portal_url}/@@caching-controlpanel;
+               "
+               i18n:translate="label_settings"
+            >Change settings</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link active"
+               href=""
+               tal:attributes="
+                 href string:${portal_url}/@@caching-controlpanel-import;
+               "
+               i18n:translate="label_import"
+            >Import settings</a>
+          </li>
+          <li class="nav-item"
+              tal:condition="view/purgingEnabled"
+          >
+            <a class="nav-link"
+               href=""
+               tal:attributes="
+                 href string:${portal_url}/@@caching-controlpanel-purge;
+               "
+               i18n:translate="label_purging"
+            >Purge caching proxy</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link"
+               href=""
+               tal:attributes="
+                 href string:${portal_url}/@@caching-controlpanel-ramcache;
+               "
+               i18n:translate="label_ramcache"
+            >RAM cache</a>
+          </li>
+        </ul>
+      </div>
 
-            <div metal:use-macro="context/global_statusmessage/macros/portal_message">
+      <div metal:use-macro="context/global_statusmessage/macros/portal_message">
             Portal status message
-            </div>
+      </div>
 
-            <div class="configlet">
+      <div class="configlet">
 
-                <h1 class="documentFirstHeading"
-                    i18n:translate="heading_caching_import">Import caching profiles</h1>
+        <h1 class="documentFirstHeading"
+            i18n:translate="heading_caching_import"
+        >Import caching profiles</h1>
 
-                <a id="setup-link" class="link-parent"
-                    tal:attributes="href string:${portal_url}/@@overview-controlpanel"
-                    i18n:translate="label_up_to_plone_setup">
+        <a class="link-parent"
+           id="setup-link"
+           tal:attributes="
+             href string:${portal_url}/@@overview-controlpanel;
+           "
+           i18n:translate="label_up_to_plone_setup"
+        >
                         Up to Site Setup
-                </a>
+        </a>
 
-                <p class="form-text"
-                    i18n:translate="description_caching_ipmort">
+        <p class="form-text"
+           i18n:translate="description_caching_ipmort"
+        >
                     Choose a profile below to import cache settings. Additional
                     profiles may be installed by third party products.
-                    <strong>Warning:</strong> This may overwrite existing
+          <strong>Warning:</strong>
+           This may overwrite existing
                     settings.
-                </p>
+        </p>
 
-                <form name="profiles" tal:attributes="action request/URL" method="post"
-                    class="pat-formunloadalert"
-                    tal:define="errors view/errors">
+        <form class="pat-formunloadalert"
+              method="post"
+              name="profiles"
+              tal:define="
+                errors view/errors;
+              "
+              tal:attributes="
+                action request/URL;
+              "
+        >
 
-                    <div class="mb-3 field form-check ${python:'error' if errors else ''}">
+          <div class="mb-3 field form-check ${python:'error' if errors else ''}">
 
-                        <div
-                            class="invalid-feedback"
-                            tal:condition="errors/profile | nothing"
-                            tal:content="errors/profile"
-                            />
+            <div class="invalid-feedback"
+                 tal:condition="errors/profile | nothing"
+                 tal:content="errors/profile"
+            ></div>
 
-                        <div tal:repeat="profile view/profiles">
+            <div tal:repeat="profile view/profiles">
 
-                            <input class="form-check-input"
-                                type="radio"
-                                name="profile"
-                                tal:attributes="id string:profile-${repeat/profile/index};
-                                                value profile/id"
-                                />
+              <input class="form-check-input"
+                     name="profile"
+                     type="radio"
+                     tal:attributes="
+                       id string:profile-${repeat/profile/index};
+                       value profile/id;
+                     "
+              />
 
-                            <label class="form-check-label"
-                                tal:attributes="for string:profile-${repeat/profile/index}"
-                                tal:content="profile/title" i18n:translate=""
-                                />
+              <label class="form-check-label"
+                     tal:content="profile/title"
+                     tal:attributes="
+                       for string:profile-${repeat/profile/index};
+                     "
+                     i18n:translate=""
+              ></label>
 
-                            <p class="discreet" tal:content="profile/description" i18n:translate=""/>
+              <p class="discreet"
+                 tal:content="profile/description"
+                 i18n:translate=""
+              ></p>
 
-                        </div>
-                    </div>
+            </div>
+          </div>
 
-                    <div class="field">
-                        <input type="hidden" name="snapshot:boolean:default" value="" />
-                        <input
-                            type="checkbox"
-                            name="snapshot:boolean"
-                            id="snapshot"
-                            value="1"
-                            tal:attributes="checked python:'checked' if request.get('snapshot', True) else None"
-                            />
+          <div class="field">
+            <input name="snapshot:boolean:default"
+                   type="hidden"
+                   value=""
+            />
+            <input id="snapshot"
+                   name="snapshot:boolean"
+                   type="checkbox"
+                   value="1"
+                   tal:attributes="
+                     checked python:'checked' if request.get('snapshot', True) else None;
+                   "
+            />
 
-                        <label for="snapshot" i18n:translate="label_snapshot">
+            <label for="snapshot"
+                   i18n:translate="label_snapshot"
+            >
                             Take a snapshot of the site prior to importing new
                             setting.
-                        </label>
-                        <div class="formHelp" i18n:translate="help_snapshot">
+            </label>
+            <div class="formHelp"
+                 i18n:translate="help_snapshot"
+            >
                             This allows rollback to a previous state via the
-                            <em>portal_setup</em> tool.
-                        </div>
-                    </div>
-
-                    <div class="formControls">
-                        <button
-                            class="btn btn-primary"
-                            type="submit"
-                            name="form.button.Import"
-                            value="Import"
-                            i18n:attributes="value"
-                            i18n:translate=""
-                        >
-                            Import
-                        </button>
-                    </div>
-
-                    <input tal:replace="structure context/@@authenticator/authenticator" />
-
-                </form>
+              <em>portal_setup</em>
+               tool.
             </div>
+          </div>
+
+          <div class="formControls">
+            <button class="btn btn-primary"
+                    name="form.button.Import"
+                    type="submit"
+                    value="Import"
+                    i18n:attributes="value"
+                    i18n:translate=""
+            >
+                            Import
+            </button>
+          </div>
+
+          <input tal:replace="structure context/@@authenticator/authenticator" />
+
+        </form>
+      </div>
     </div>
 
-</body>
+  </body>
 </html>

--- a/plone/app/caching/browser/purge.pt
+++ b/plone/app/caching/browser/purge.pt
@@ -1,145 +1,198 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
-      xmlns:tal="http://xml.zope.org/namespaces/tal"
-      xmlns:metal="http://xml.zope.org/namespaces/metal"
+<html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    lang="en"
-    metal:use-macro="context/prefs_main_template/macros/master"
-    i18n:domain="plone">
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      lang="en"
+      metal:use-macro="context/prefs_main_template/macros/master"
+      xml:lang="en"
+      i18n:domain="plone"
+>
 
-<body>
+  <body>
 
-<div metal:fill-slot="prefs_configlet_main">
+    <div metal:fill-slot="prefs_configlet_main">
 
-            <div class="autotabs">
-                <ul class="nav nav-tabs">
-                    <li class="nav-item">
-                        <a class="nav-link"
-                           href=""
-                           tal:attributes="href string:${portal_url}/@@caching-controlpanel"
-                           i18n:translate="label_settings">Change settings</a>
-                      </li>
-                      <li class="nav-item">
-                        <a class="nav-link"
-                           href=""
-                           tal:attributes="href string:${portal_url}/@@caching-controlpanel-import"
-                           i18n:translate="label_import">Import settings</a>
-                      </li>
-                      <li tal:condition="view/purgingEnabled" class="nav-item">
-                        <a class="nav-link active"
-                           href=""
-                           tal:attributes="href string:${portal_url}/@@caching-controlpanel-purge"
-                           i18n:translate="label_purging">Purge caching proxy</a>
-                      </li>
-                      <li class="nav-item">
-                        <a class="nav-link"
-                           href=""
-                           tal:attributes="href string:${portal_url}/@@caching-controlpanel-ramcache"
-                           i18n:translate="label_ramcache">RAM cache</a>
-                      </li>
-                </ul>
-            </div>
+      <div class="autotabs">
+        <ul class="nav nav-tabs">
+          <li class="nav-item">
+            <a class="nav-link"
+               href=""
+               tal:attributes="
+                 href string:${portal_url}/@@caching-controlpanel;
+               "
+               i18n:translate="label_settings"
+            >Change settings</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link"
+               href=""
+               tal:attributes="
+                 href string:${portal_url}/@@caching-controlpanel-import;
+               "
+               i18n:translate="label_import"
+            >Import settings</a>
+          </li>
+          <li class="nav-item"
+              tal:condition="view/purgingEnabled"
+          >
+            <a class="nav-link active"
+               href=""
+               tal:attributes="
+                 href string:${portal_url}/@@caching-controlpanel-purge;
+               "
+               i18n:translate="label_purging"
+            >Purge caching proxy</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link"
+               href=""
+               tal:attributes="
+                 href string:${portal_url}/@@caching-controlpanel-ramcache;
+               "
+               i18n:translate="label_ramcache"
+            >RAM cache</a>
+          </li>
+        </ul>
+      </div>
 
-            <div metal:use-macro="context/global_statusmessage/macros/portal_message">
+      <div metal:use-macro="context/global_statusmessage/macros/portal_message">
             Portal status message
-            </div>
+      </div>
 
-            <div class="configlet">
+      <div class="configlet">
 
-                <h1 class="documentFirstHeading"
-                    i18n:translate="heading_caching_purging">Purge caching proxy</h1>
+        <h1 class="documentFirstHeading"
+            i18n:translate="heading_caching_purging"
+        >Purge caching proxy</h1>
 
-                <a id="setup-link" class="link-parent"
-                    tal:attributes="href string:${portal_url}/@@overview-controlpanel"
-                    i18n:translate="label_up_to_plone_setup">
+        <a class="link-parent"
+           id="setup-link"
+           tal:attributes="
+             href string:${portal_url}/@@overview-controlpanel;
+           "
+           i18n:translate="label_up_to_plone_setup"
+        >
                         Up to Site Setup
-                </a>
+        </a>
 
-                <p class="form-text"
-                    i18n:translate="description_cache_purging">
+        <p class="form-text"
+           i18n:translate="description_cache_purging"
+        >
                     If you have enabled a caching proxy, it may end up caching
                     objects which are no longer current. Plone will attempt
                     to automatically purge objects when they change, but if
                     you are seeing stale objects in your cache, you can purge
                     them manually below.
-                </p>
+        </p>
 
-                <div class="alert alert-info"
-                     tal:condition="view/purgeLog | nothing">
-                    <strong i18n:translate="heading_purged">Status</strong>
-                    <span tal:omit-tag="" i18n:translate="description_purged">
+        <div class="alert alert-info"
+             tal:condition="view/purgeLog | nothing"
+        >
+          <strong i18n:translate="heading_purged">Status</strong>
+          <span tal:omit-tag=""
+                i18n:translate="description_purged"
+          >
                         The following items were purged:
-                    </span>
-                    <ul>
-                      <li tal:repeat="log view/purgeLog" tal:content="log" />
-                    </ul>
-                </div>
+          </span>
+          <ul>
+            <li tal:repeat="log view/purgeLog"
+                tal:content="log"
+            ></li>
+          </ul>
+        </div>
 
-                <form name="purge" tal:attributes="action string:${request/URL}" method="post"
-                    class="pat-formunloadalert"
-                    tal:define="errors view/errors">
+        <form class="pat-formunloadalert"
+              method="post"
+              name="purge"
+              tal:define="
+                errors view/errors;
+              "
+              tal:attributes="
+                action string:${request/URL};
+              "
+        >
 
-                    <div class="mb-3 field ${python:'error' if error else ''}"
-                         tal:define="error errors/urls | nothing"
-                    >
+          <div class="mb-3 field ${python:'error' if error else ''}"
+               tal:define="
+                 error errors/urls | nothing;
+               "
+          >
 
-                        <label class="form-label"
-                               for="purgeURLs" i18n:translate="label_urls">URLs to purge</label>
+            <label class="form-label"
+                   for="purgeURLs"
+                   i18n:translate="label_urls"
+            >URLs to purge</label>
 
 
-                        <div class="invalid-feedback"
-                             tal:content="error" tal:condition="error" />
+            <div class="invalid-feedback"
+                 tal:condition="error"
+                 tal:content="error"
+            ></div>
 
-                        <textarea class="form-control"
-                                  id="purgeURLs" name="urls:lines" cols="40" rows="4"></textarea>
+            <textarea class="form-control"
+                      id="purgeURLs"
+                      cols="40"
+                      name="urls:lines"
+                      rows="4"
+            ></textarea>
 
-                        <div class="form-text" i18n:translate="help_urls">
+            <div class="form-text"
+                 i18n:translate="help_urls"
+            >
                             Enter URLs to purge, one per line, below. You can
                             either enter a full URL including a domain, or a path
-                            relative to the site root, starting with a <em>/</em>.
-                        </div>
-                    </div>
+                            relative to the site root, starting with a
+              <em>/</em>.
+            </div>
+          </div>
 
-                    <div class="mb-3 field form-check">
-                        <input type="hidden" name="synchronous:boolean:default" value="" />
-                        <input class="form-check-input"
-                            type="checkbox"
-                            name="synchronous:boolean"
-                            id="purgeSynchronous"
-                            value="1"
-                            checked="checked"
-                            />
+          <div class="mb-3 field form-check">
+            <input name="synchronous:boolean:default"
+                   type="hidden"
+                   value=""
+            />
+            <input class="form-check-input"
+                   id="purgeSynchronous"
+                   checked="checked"
+                   name="synchronous:boolean"
+                   type="checkbox"
+                   value="1"
+            />
 
-                        <label class="form-check-label"
-                               for="purgeSynchronous" i18n:translate="label_synchronous">
+            <label class="form-check-label"
+                   for="purgeSynchronous"
+                   i18n:translate="label_synchronous"
+            >
                             Purge synchronously
-                        </label>
-                        <div class="form-text" i18n:translate="help_synchronous">
+            </label>
+            <div class="form-text"
+                 i18n:translate="help_synchronous"
+            >
                             Select this option to wait while the purge completes.
                             This allows you to see the results of the purges.
                             Purging asynchronously will return immediately, but
                             you will need to check your caching proxy's log files
                             to see if the purge actually succeeded.
-                        </div>
-                    </div>
-
-                    <div class="formControls">
-                        <button
-                            type="submit"
-                            name="form.button.Purge"
-                            class="btn btn-primary"
-                            value="Purge"
-                            i18n:attributes="value"
-                            i18n:translate=""
-                        >
-                            Purge
-                        </button>
-                    </div>
-
-                    <input tal:replace="structure context/@@authenticator/authenticator" />
-
-                </form>
             </div>
+          </div>
 
-</div>
-</body>
+          <div class="formControls">
+            <button class="btn btn-primary"
+                    name="form.button.Purge"
+                    type="submit"
+                    value="Purge"
+                    i18n:attributes="value"
+                    i18n:translate=""
+            >
+                            Purge
+            </button>
+          </div>
+
+          <input tal:replace="structure context/@@authenticator/authenticator" />
+
+        </form>
+      </div>
+
+    </div>
+  </body>
 </html>

--- a/plone/app/caching/browser/ramcache.pt
+++ b/plone/app/caching/browser/ramcache.pt
@@ -1,110 +1,143 @@
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en"
-      xmlns:tal="http://xml.zope.org/namespaces/tal"
-      xmlns:metal="http://xml.zope.org/namespaces/metal"
+<html xmlns="http://www.w3.org/1999/xhtml"
       xmlns:i18n="http://xml.zope.org/namespaces/i18n"
-    lang="en"
-    metal:use-macro="context/prefs_main_template/macros/master"
-    i18n:domain="plone">
+      xmlns:metal="http://xml.zope.org/namespaces/metal"
+      xmlns:tal="http://xml.zope.org/namespaces/tal"
+      lang="en"
+      metal:use-macro="context/prefs_main_template/macros/master"
+      xml:lang="en"
+      i18n:domain="plone"
+>
 
-<body>
+  <body>
 
-<div metal:fill-slot="prefs_configlet_main">
+    <div metal:fill-slot="prefs_configlet_main">
 
-            <div class="autotabs">
-                <ul class="nav nav-tabs">
-                    <li class="nav-item">
-                        <a class="nav-link"
-                           href=""
-                           tal:attributes="href string:${portal_url}/@@caching-controlpanel"
-                           i18n:translate="label_settings">Change settings</a>
-                      </li>
-                      <li class="nav-item">
-                        <a class="nav-link"
-                           href=""
-                           tal:attributes="href string:${portal_url}/@@caching-controlpanel-import"
-                           i18n:translate="label_import">Import settings</a>
-                      </li>
-                      <li tal:condition="view/purgingEnabled" class="nav-item">
-                        <a class="nav-link"
-                           href=""
-                           tal:attributes="href string:${portal_url}/@@caching-controlpanel-purge"
-                           i18n:translate="label_purging">Purge caching proxy</a>
-                      </li>
-                      <li class="nav-item">
-                        <a class="nav-link active"
-                           href=""
-                           tal:attributes="href string:${portal_url}/@@caching-controlpanel-ramcache"
-                           i18n:translate="label_ramcache">RAM cache</a>
-                      </li>
-                </ul>
-            </div>
+      <div class="autotabs">
+        <ul class="nav nav-tabs">
+          <li class="nav-item">
+            <a class="nav-link"
+               href=""
+               tal:attributes="
+                 href string:${portal_url}/@@caching-controlpanel;
+               "
+               i18n:translate="label_settings"
+            >Change settings</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link"
+               href=""
+               tal:attributes="
+                 href string:${portal_url}/@@caching-controlpanel-import;
+               "
+               i18n:translate="label_import"
+            >Import settings</a>
+          </li>
+          <li class="nav-item"
+              tal:condition="view/purgingEnabled"
+          >
+            <a class="nav-link"
+               href=""
+               tal:attributes="
+                 href string:${portal_url}/@@caching-controlpanel-purge;
+               "
+               i18n:translate="label_purging"
+            >Purge caching proxy</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link active"
+               href=""
+               tal:attributes="
+                 href string:${portal_url}/@@caching-controlpanel-ramcache;
+               "
+               i18n:translate="label_ramcache"
+            >RAM cache</a>
+          </li>
+        </ul>
+      </div>
 
-            <div metal:use-macro="context/global_statusmessage/macros/portal_message">
+      <div metal:use-macro="context/global_statusmessage/macros/portal_message">
             Portal status message
-            </div>
+      </div>
 
-            <div class="configlet">
+      <div class="configlet">
 
-                <h1 class="documentFirstHeading"
-                    i18n:translate="heading_ramcache_stats">RAM cache statistics</h1>
+        <h1 class="documentFirstHeading"
+            i18n:translate="heading_ramcache_stats"
+        >RAM cache statistics</h1>
 
-                <a id="setup-link" class="link-parent"
-                    tal:attributes="href string:${portal_url}/@@overview-controlpanel"
-                    i18n:translate="label_up_to_plone_setup">
+        <a class="link-parent"
+           id="setup-link"
+           tal:attributes="
+             href string:${portal_url}/@@overview-controlpanel;
+           "
+           i18n:translate="label_up_to_plone_setup"
+        >
                         Up to Site Setup
-                </a>
+        </a>
 
-                <p class="form-text"
-                    i18n:translate="description_ramcache_stats">
+        <p class="form-text"
+           i18n:translate="description_ramcache_stats"
+        >
                     The table below shows statistics for the default RAM
-                    cache. You can use the <em>Purge</em> button to manually
+                    cache. You can use the
+          <em>Purge</em>
+           button to manually
                     clear the cache if you suspect there are stale items there.
-                </p>
+        </p>
 
-                <form name="purge" tal:attributes="action string:${request/URL}" method="post"
-                    class="pat-formunloadalert"
-                    tal:define="errors view/errors">
+        <form class="pat-formunloadalert"
+              method="post"
+              name="purge"
+              tal:define="
+                errors view/errors;
+              "
+              tal:attributes="
+                action string:${request/URL};
+              "
+        >
 
-                  <table class="table table-striped table-responsive"
-                         tal:define="stats view/ramCache/getStatistics"
-                         summary="RAM cache statistics"
-                         i18n:attributes="summary heading_ramcache_stats;">
-                    <thead>
-                      <th i18n:translate="label_cache_key">Key</th>
-                      <th i18n:translate="label_cache_hits">Hits</th>
-                      <th i18n:translate="label_cache_misses">Misses</th>
-                      <th i18n:translate="label_cache_size_bytes">Size (bytes)</th>
-                      <th i18n:translate="label_cache_entries">Entries</th>
-                    </thead>
-                    <tbody>
-                      <tr tal:repeat="data stats">
-                        <td><span tal:content="data/path">&nbsp;</span></td>
-                        <td><span tal:content="data/hits">&nbsp;</span></td>
-                        <td><span tal:content="data/misses">&nbsp;</span></td>
-                        <td><span tal:content="data/size">&nbsp;</span></td>
-                        <td><span tal:content="data/entries">&nbsp;</span></td>
-                      </tr>
-                    </tbody>
-                  </table>
+          <table class="table table-striped table-responsive"
+                 summary="RAM cache statistics"
+                 tal:define="
+                   stats view/ramCache/getStatistics;
+                 "
+                 i18n:attributes="summary heading_ramcache_stats;"
+          >
+            <thead>
+              <th i18n:translate="label_cache_key">Key</th>
+              <th i18n:translate="label_cache_hits">Hits</th>
+              <th i18n:translate="label_cache_misses">Misses</th>
+              <th i18n:translate="label_cache_size_bytes">Size (bytes)</th>
+              <th i18n:translate="label_cache_entries">Entries</th>
+            </thead>
+            <tbody>
+              <tr tal:repeat="data stats">
+                <td><span tal:content="data/path">&nbsp;</span></td>
+                <td><span tal:content="data/hits">&nbsp;</span></td>
+                <td><span tal:content="data/misses">&nbsp;</span></td>
+                <td><span tal:content="data/size">&nbsp;</span></td>
+                <td><span tal:content="data/entries">&nbsp;</span></td>
+              </tr>
+            </tbody>
+          </table>
 
-                    <div class="formControls">
-                        <button
-                            class="btn btn-primary"
-                            type="submit"
-                            name="form.button.Purge"
-                            value="Purge"
-                            i18n:attributes="value"
-                            i18n:translate=""
-                        >
+          <div class="formControls">
+            <button class="btn btn-primary"
+                    name="form.button.Purge"
+                    type="submit"
+                    value="Purge"
+                    i18n:attributes="value"
+                    i18n:translate=""
+            >
                           Purge
-                        </button>
-                    </div>
+            </button>
+          </div>
 
-                    <input tal:replace="structure context/@@authenticator/authenticator" />
+          <input tal:replace="structure context/@@authenticator/authenticator" />
 
-                </form>
-            </div>
+        </form>
+      </div>
 
-</div>
-</body>
+    </div>
+  </body>
 </html>

--- a/plone/app/caching/lookup.py
+++ b/plone/app/caching/lookup.py
@@ -54,7 +54,6 @@ class ContentItemLookup:
         self.request = request
 
     def __call__(self):
-
         # 1. Attempt to look up a ruleset using the default lookup
         ruleset = lookup(self.published)
         if ruleset is not None:

--- a/plone/app/caching/operations/utils.py
+++ b/plone/app/caching/operations/utils.py
@@ -399,7 +399,6 @@ def isModified(request, etag=None, lastModified=None):
 
     # Check the modification date
     if ifModifiedSince and lastModified is not None:
-
         # Attempt to get a date
 
         ifModifiedSince = ifModifiedSince.split(";")[0]

--- a/plone/app/caching/purge.py
+++ b/plone/app/caching/purge.py
@@ -160,7 +160,6 @@ class DiscussionItemPurgePaths:
 
     @memoize
     def _getRoot(self):
-
         plone_utils = getToolByName(self.context, "plone_utils", None)
         if plone_utils is None:
             return

--- a/plone/app/caching/setuphandlers.py
+++ b/plone/app/caching/setuphandlers.py
@@ -13,7 +13,6 @@ def enableExplicitMode():
 
 
 def importVarious(context):
-
     if not context.readDataFile("plone.app.caching.txt"):
         return
 

--- a/plone/app/caching/testing.py
+++ b/plone/app/caching/testing.py
@@ -37,7 +37,6 @@ class FauxPurger:
 
 class PloneAppCachingBase(PloneSandboxLayer):
     def setUpZope(self, app, configurationContext):
-
         # Load ZCML
         import plone.app.caching
 
@@ -57,7 +56,6 @@ class PloneAppCachingBase(PloneSandboxLayer):
 
 
 class PloneAppCaching(PloneAppCachingBase):
-
     defaultBases = (PLONE_APP_CONTENTTYPES_FIXTURE,)
 
 

--- a/plone/app/caching/tests/test_etags.py
+++ b/plone/app/caching/tests/test_etags.py
@@ -31,7 +31,6 @@ class DummyPublished:
 
 
 class TestETags(unittest.TestCase):
-
     layer = UNIT_TESTING
 
     def setUp(self):

--- a/plone/app/caching/tests/test_integration.py
+++ b/plone/app/caching/tests/test_integration.py
@@ -175,7 +175,6 @@ class TestOperations(unittest.TestCase):
         # self.assertTrue('Cache-Control' in browser.headers)
 
     def test_auto_purge_content_types(self):
-
         setRoles(self.portal, TEST_USER_ID, ("Manager",))
 
         # Non-folder content

--- a/plone/app/caching/tests/test_lastmodified.py
+++ b/plone/app/caching/tests/test_lastmodified.py
@@ -24,7 +24,6 @@ class FauxDataManager:
 
 
 class TestLastModified(unittest.TestCase):
-
     layer = UNIT_TESTING
 
     def setUp(self):
@@ -148,7 +147,6 @@ class TestLastModified(unittest.TestCase):
 
         @implementer(ICatalogableDublinCore)
         class Dummy:
-
             _mod = None
 
             def modified(self):
@@ -172,7 +170,6 @@ class TestLastModified(unittest.TestCase):
 
         @implementer(IDCTimes)
         class Dummy:
-
             _mod = None
 
             @property

--- a/plone/app/caching/tests/test_lookup.py
+++ b/plone/app/caching/tests/test_lookup.py
@@ -76,7 +76,6 @@ class DummyView(BrowserView):
 
 
 class TestContentItemLookup(unittest.TestCase):
-
     layer = IMPLICIT_RULESET_REGISTRY_UNIT_TESTING
 
     def setUp(self):

--- a/plone/app/caching/tests/test_operation_parameters.py
+++ b/plone/app/caching/tests/test_operation_parameters.py
@@ -35,7 +35,6 @@ class TestOperationParameters(unittest.TestCase):
         setRequest(None)
 
     def test_anon_only(self):
-
         # Add folder content
         setRoles(self.portal, TEST_USER_ID, ("Manager",))
         self.portal.invokeFactory("Folder", "f1")

--- a/plone/app/caching/tests/test_operation_utils.py
+++ b/plone/app/caching/tests/test_operation_utils.py
@@ -40,7 +40,6 @@ def normalize_response_cache(value):
 
 
 class ResponseModificationHelpersTest(unittest.TestCase):
-
     layer = UNIT_TESTING
 
     def setUp(self):
@@ -392,7 +391,6 @@ class ResponseModificationHelpersTest(unittest.TestCase):
 
 
 class ResponseInterceptorHelpersTest(unittest.TestCase):
-
     layer = UNIT_TESTING
 
     def setUp(self):
@@ -537,7 +535,6 @@ class ResponseInterceptorHelpersTest(unittest.TestCase):
 
 
 class CacheCheckHelpersTest(unittest.TestCase):
-
     layer = UNIT_TESTING
 
     def setUp(self):
@@ -841,7 +838,6 @@ class CacheCheckHelpersTest(unittest.TestCase):
 
 
 class MiscHelpersTest(unittest.TestCase):
-
     layer = UNIT_TESTING
 
     def setUp(self):
@@ -1264,7 +1260,6 @@ class MiscHelpersTest(unittest.TestCase):
 
 
 class RAMCacheTest(unittest.TestCase):
-
     layer = UNIT_TESTING
 
     def setUp(self):

--- a/plone/app/caching/tests/test_profile_with_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_with_caching_proxy.py
@@ -304,7 +304,6 @@ class TestProfileWithCaching(unittest.TestCase):
         self.assertEqual("200 OK", browser.headers["Status"].upper())
 
     def test_content_feeds(self):
-
         catalog = self.portal["portal_catalog"]
         skins_tool = self.portal["portal_skins"]
 
@@ -405,7 +404,6 @@ class TestProfileWithCaching(unittest.TestCase):
         self.assertIsNone(browser.headers.get("X-RAMCache"))
 
     def test_content_files(self):
-
         # Add folder content
         setRoles(self.portal, TEST_USER_ID, ("Manager",))
         self.portal.invokeFactory("Folder", "f1")

--- a/plone/app/caching/tests/test_profile_without_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_without_caching_proxy.py
@@ -56,7 +56,6 @@ class TestProfileWithoutCaching(unittest.TestCase):
         setRequest(None)
 
     def test_composite_views(self):
-
         catalog = self.portal["portal_catalog"]
         default_skin = self.portal["portal_skins"].default_skin
 
@@ -276,7 +275,6 @@ class TestProfileWithoutCaching(unittest.TestCase):
         self.assertEqual("200 OK", browser.headers["Status"].upper())
 
     def test_content_feeds(self):
-
         catalog = self.portal["portal_catalog"]
         default_skin = self.portal["portal_skins"].default_skin
 
@@ -377,7 +375,6 @@ class TestProfileWithoutCaching(unittest.TestCase):
         self.assertIsNone(browser.headers.get("X-RAMCache"))
 
     def test_content_files(self):
-
         # Add folder content
         setRoles(self.portal, TEST_USER_ID, ("Manager",))
         self.portal.invokeFactory("Folder", "f1")

--- a/plone/app/caching/tests/test_purge.py
+++ b/plone/app/caching/tests/test_purge.py
@@ -92,7 +92,6 @@ class FauxNonContent(Explicit):
 
 @implementer(IBrowserDefault)
 class FauxContent(FauxNonContent):
-
     portal_type = "testtype"
 
     def defaultView(self):
@@ -105,7 +104,6 @@ class FauxDiscussable(Explicit):
 
 
 class TestPurgeRedispatch(unittest.TestCase):
-
     layer = UNIT_TESTING
 
     def setUp(self):
@@ -182,7 +180,6 @@ class TestPurgeRedispatch(unittest.TestCase):
 
 
 class TestContentPurgePaths(unittest.TestCase):
-
     layer = UNIT_TESTING
 
     def test_no_default_view(self):
@@ -230,7 +227,6 @@ class TestContentPurgePaths(unittest.TestCase):
 
 
 class TestDiscussionItemPurgePaths(unittest.TestCase):
-
     layer = UNIT_TESTING
 
     def setUp(self):
@@ -319,11 +315,9 @@ class TestDiscussionItemPurgePaths(unittest.TestCase):
 
 
 class TestScalesPurgePaths(unittest.TestCase):
-
     layer = PLONE_APP_CACHING_FUNCTIONAL_TESTING
 
     def setUp(self):
-
         self.portal = self.layer["portal"]
         setRoles(self.portal, TEST_USER_ID, ["Manager"])
         self.portal.invokeFactory("Folder", "media")
@@ -346,7 +340,6 @@ class TestScalesPurgePaths(unittest.TestCase):
         @implementer(IBehaviorAssignable)
         @adapter(IDocument)
         class TestingAssignable:
-
             enabled = [ILeadImageBehavior]
             name = "plone.leadimage"
 

--- a/plone/app/caching/tests/test_utils.py
+++ b/plone/app/caching/tests/test_utils.py
@@ -98,7 +98,6 @@ class DummyNotBrowserDefault(Explicit):
 
 
 class TestIsPurged(unittest.TestCase):
-
     layer = UNIT_TESTING
 
     def setUp(self):
@@ -155,7 +154,6 @@ class TestIsPurged(unittest.TestCase):
 
 
 class TestGetObjectDefaultPath(unittest.TestCase):
-
     layer = UNIT_TESTING
 
     def test_not_content(self):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,3 @@
-[build_sphinx]
-source-dir = docs/source
-build-dir  = docs
-all_files  = 1
-
-[upload_sphinx]
-upload-dir = docs/html
-
 # Generated from:
 # https://github.com/plone/meta/tree/master/config/default
 [bdist_wheel]
@@ -27,5 +19,6 @@ ignore =
 ignore =
     .editorconfig
     .meta.toml
+    .pre-commit-config.yaml
     tox.ini
     lint-requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -6,50 +6,50 @@ envlist =
     lint
 
 [testenv]
-py_files = git ls-files "*.py"
-text_files = git ls-files "*.rst" "*.md"
-xml_files = git ls-files "*.xml"
-zcml_files = git ls-files "*.zcml"
 allowlist_externals =
     sh
 
 [testenv:format]
-description = automatically reformat python code
+description = automatically reformat code
 skip_install = true
 deps =
-    pyupgrade
-    isort
-    black
-    zpretty
-    -c lint-requirements.txt
+    pre-commit
 commands =
-    sh -c '{[testenv]py_files} | xargs pyupgrade --py38-plus'
-    sh -c '{[testenv]py_files} | xargs isort'
-    sh -c '{[testenv]py_files} | xargs black'
-    sh -c '{[testenv]xml_files} | xargs zpretty -x -i'
-    sh -c '{[testenv]zcml_files} | xargs zpretty -z -i'
+    pre-commit run -a pyupgrade
+    pre-commit run -a isort
+    pre-commit run -a black
+    pre-commit run -a zpretty
 
 [testenv:lint]
 description = run linters that will help improve the code style
 skip_install = true
 deps =
-    flake8
-    codespell
-    tomli  # needed for codespell to read pyproject.toml
-    check-manifest
-    pyroma
-    -c lint-requirements.txt
+    pre-commit
 commands =
-    sh -c '{[testenv]py_files} | xargs flake8'
-    sh -c '{[testenv]py_files} | xargs codespell'
-    sh -c '{[testenv]text_files} | xargs codespell'
-    check-manifest
-    pyroma -n 10 .
+    pre-commit run -a
 
 [testenv:dependencies]
 description = check if the package defines all its dependencies
 deps =
-    z3c.dependencychecker
-    -c lint-requirements.txt
+    z3c.dependencychecker==2.10
 commands =
     dependencychecker
+
+[testenv:dependencies-graph]
+description = generate a graph with the distribution dependencies
+deps =
+    pipdeptree==2.3.3
+    graphviz  # optional dependency of pipdeptree
+commands =
+    sh -c 'pipdeptree --exclude setuptools,pipdeptree,wheel --graph-output svg > dependencies.svg'
+
+[testenv:test]
+description = run the tests of the distribution
+deps =
+    plone.app.caching[test]
+    pytest
+    gocept.pytestlayer
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+commands =
+    pip install -e .[test]
+    pytest


### PR DESCRIPTION
This adds pre-commit, zpretty, tests, etc.

I *removed* codespell for now: I can't get it to ignore some words.  See commit 9287fa1ce265da5afb043d4cdfddaa0d8ce7a668.

Ah, and the tests fail.  I need to look into that.  Work in progress.