### PR TITLE
Configuring with plone/meta

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -2,7 +2,7 @@
 # https://github.com/plone/meta/tree/master/config/default
 [meta]
 template = "default"
-commit-id = "cbbcff93"
+commit-id = "13d8d6c0"
 
 [dependencies]
 mappings = [

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
     -   id: black
 -   repo: https://github.com/collective/zpretty
-    rev: 3.0.1
+    rev: 3.0.2
     hooks:
     -   id: zpretty
 -   repo: https://github.com/PyCQA/flake8
@@ -37,6 +37,6 @@ repos:
     hooks:
     -   id: check-manifest
 -   repo: https://github.com/regebro/pyroma
-    rev: "4.1"
+    rev: "4.2"
     hooks:
     -   id: pyroma

--- a/news/13d8d6c0.internal
+++ b/news/13d8d6c0.internal
@@ -1,0 +1,2 @@
+Update configuration files.
+[plone devs]

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ commands =
 usedevelop = true
 deps =
     zope.testrunner
+    plone.restapi
     -c https://dist.plone.org/release/6.0-dev/constraints.txt
 commands =
     zope-testrunner --test-path={toxinidir} -s plone.app.caching

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@
 envlist =
     format
     lint
+    test
 
 [testenv]
 allowlist_externals =
@@ -29,27 +30,21 @@ commands =
     pre-commit run -a
 
 [testenv:dependencies]
-description = check if the package defines all its dependencies
+description = check if the package defines all its dependencies and generate a graph out of them
 deps =
-    z3c.dependencychecker==2.10
-commands =
-    dependencychecker
-
-[testenv:dependencies-graph]
-description = generate a graph with the distribution dependencies
-deps =
-    pipdeptree==2.3.3
+    z3c.dependencychecker==2.11
+    pipdeptree==2.5.1
     graphviz  # optional dependency of pipdeptree
 commands =
-    sh -c 'pipdeptree --exclude setuptools,pipdeptree,wheel --graph-output svg > dependencies.svg'
+    dependencychecker
+    sh -c 'pipdeptree --exclude setuptools,pipdeptree,wheel,pipdeptree,z3c.dependencychecker,zope.interface,zope.component --graph-output svg > dependencies.svg'
 
-; [testenv:test]
-; description = run the tests of the distribution
-; deps =
-;     plone.app.caching[test]
-;     pytest
-;     gocept.pytestlayer
-;     -c https://dist.plone.org/release/6.0-dev/constraints.txt
-; commands =
-;     pip install -e .[test]
-;     pytest
+[testenv:test]
+usedevelop = true
+deps =
+    zope.testrunner
+    -c https://dist.plone.org/release/6.0-dev/constraints.txt
+commands =
+    zope-testrunner --test-path={toxinidir} -s plone.app.caching
+extras =
+    test


### PR DESCRIPTION
Now with tests 🤖 

Note that they fail as `plone.app.caching` does not declare a dependency on `plone.restapi` but the tests expect it to be there, otherwise fails, as one can see.

Should we add `plone.restapi` as a testing dependency?

For the time being, I'm installing `plone.restapi` inside the `tox.ini` environment to get the tests to pass.