### PR TITLE
Update resourceRegistries ETag to use the config registry mtime

### DIFF
--- a/news/93.feature
+++ b/news/93.feature
@@ -1,0 +1,4 @@
+Update the resourceRegistries ETag to use the config registry modification time.
+This time is set since Plone 6.0.4.
+Fixes `issue 93 <https://github.com/plone/plone.app.caching/issues/93>`_.
+[maurits]

--- a/plone/app/caching/tests/test_profile_without_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_without_caching_proxy.py
@@ -92,6 +92,13 @@ class TestProfileWithoutCaching(unittest.TestCase):
         # - set the mod date on the resource registries?  Probably.
         transaction.commit()
 
+        # Since Plone 6.0.4 we have a modification date on the registry.
+        from Products.CMFPlone.resources.browser.resource import (
+            _RESOURCE_REGISTRY_MTIME,
+        )
+
+        mtime = str(getattr(self.registry, _RESOURCE_REGISTRY_MTIME))
+
         # Request the authenticated folder
         now = stable_now()
         browser = Browser(self.app)
@@ -108,7 +115,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         self.assertEqual(
             "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
         )
-        tag = f'"|test_user_1_|{catalog.getCounter()}|en|{default_skin}|0|0|"'
+        tag = f'"|test_user_1_|{catalog.getCounter()}|en|{default_skin}|0|0|{mtime}"'
         self.assertEqual(tag, normalize_etag(browser.headers["ETag"]))
         self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
 
@@ -123,7 +130,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         self.assertEqual(
             "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
         )
-        tag = f'"|test_user_1_|{catalog.getCounter()}|en|{default_skin}|0|1|"'
+        tag = f'"|test_user_1_|{catalog.getCounter()}|en|{default_skin}|0|1|{mtime}"'
         self.assertEqual(tag, normalize_etag(browser.headers["ETag"]))
 
         # Request the authenticated page
@@ -143,7 +150,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         self.assertEqual(
             "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
         )
-        tag = f'"|test_user_1_|{catalog.getCounter()}|en|{default_skin}|0|"'
+        tag = f'"|test_user_1_|{catalog.getCounter()}|en|{default_skin}|0|{mtime}"'
         self.assertEqual(tag, normalize_etag(browser.headers["ETag"]))
         self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
 
@@ -192,7 +199,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         self.assertEqual(
             "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
         )
-        tag = f'"||{catalog.getCounter()}|en|{default_skin}|0|0|"'
+        tag = f'"||{catalog.getCounter()}|en|{default_skin}|0|0|{mtime}"'
         self.assertEqual(tag, normalize_etag(browser.headers["ETag"]))
         self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
 
@@ -209,7 +216,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         self.assertEqual(
             "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
         )
-        tag = f'"||{catalog.getCounter()}|en|{default_skin}|0|"'
+        tag = f'"||{catalog.getCounter()}|en|{default_skin}|0|{mtime}"'
         self.assertEqual(tag, normalize_etag(browser.headers["ETag"]))
         self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
 
@@ -230,7 +237,7 @@ class TestProfileWithoutCaching(unittest.TestCase):
         self.assertEqual(
             "max-age=0, must-revalidate, private", browser.headers["Cache-Control"]
         )
-        tag = f'"||{catalog.getCounter()}|en|{default_skin}|0|"'
+        tag = f'"||{catalog.getCounter()}|en|{default_skin}|0|{mtime}"'
         self.assertEqual(tag, normalize_etag(browser.headers["ETag"]))
         self.assertGreater(now, dateutil.parser.parse(browser.headers["Expires"]))
 


### PR DESCRIPTION
This time is set since Plone 6.0.4.
Fixes https://github.com/plone/plone.app.caching/issues/93.

This removes the previous code which read `timestamp.txt` from `/portal_resources/resource_overrides/production`. This timestamp is no longer set in Plone 6, and does not influence anything.
At least that is what it looks like to me.  Would be good to have someone confirm this.