### PR TITLE
Temporary fix: change test date to June instead of May

### DIFF
--- a/news/127.tests
+++ b/news/127.tests
@@ -1,0 +1,4 @@
+Changed hardcoded test date to June instead of May to temporarily fix a testing error.
+See `issue 127 <https://github.com/plone/plone.app.caching/issues/127>`_.
+Needs a proper fix within a month.
+[maurits]

--- a/plone/app/caching/tests/test_utils.py
+++ b/plone/app/caching/tests/test_utils.py
@@ -27,7 +27,7 @@ TEST_IMAGE = pkg_resources.resource_filename("plone.app.caching.tests", "test.gi
 def stable_now():
     """Patch localized_now to allow stable results in tests."""
     tzinfo = pytz.timezone(TEST_TIMEZONE)
-    now = datetime(2013, 5, 5, 10, 0, 0).replace(microsecond=0)
+    now = datetime(2013, 6, 5, 10, 0, 0).replace(microsecond=0)
     now = tzinfo.localize(now)  # set tzinfo with correct DST offset
     return now
 


### PR DESCRIPTION
This temporarily fixes a testing error.  See https://github.com/plone/plone.app.caching/issues/127.  This gives us one month to come up with a proper fix.