### PR TITLE
Temporary fix: change test date to June instead of May [2.x]

### DIFF
--- a/news/127.tests
+++ b/news/127.tests
@@ -1,0 +1,4 @@
+Changed hardcoded test date to June instead of May to temporarily fix a testing error.
+See `issue 127 <https://github.com/plone/plone.app.caching/issues/127>`_.
+Needs a proper fix within a month.
+[maurits]

--- a/plone/app/caching/tests/test_utils.py
+++ b/plone/app/caching/tests/test_utils.py
@@ -30,7 +30,7 @@ def stable_now():
     """Patch localized_now to allow stable results in tests.
     """
     tzinfo = pytz.timezone(TEST_TIMEZONE)
-    now = datetime(2013, 5, 5, 10, 0, 0).replace(microsecond=0)
+    now = datetime(2013, 6, 5, 10, 0, 0).replace(microsecond=0)
     now = tzinfo.localize(now)  # set tzinfo with correct DST offset
     return now
 


### PR DESCRIPTION
See https://github.com/plone/plone.app.caching/issues/127. Needs a proper fix within a month.

Backported from master: Plone 5.2 needs it as well.
See failures: https://jenkins.plone.org/job/plone-5.2-python-2.7/1924/