### PR TITLE
Fixed tests that compared a stable time with a ten year old Expires handler. [5.2]

### DIFF
--- a/news/127.bugfix
+++ b/news/127.bugfix
@@ -1,0 +1,2 @@
+Fixed tests that compared a stable time with a ten year old Expires handler.
+[maurits]

--- a/news/127.tests
+++ b/news/127.tests
@@ -1,4 +1,0 @@
-Changed hardcoded test date to June instead of May to temporarily fix a testing error.
-See `issue 127 <https://github.com/plone/plone.app.caching/issues/127>`_.
-Needs a proper fix within a month.
-[maurits]

--- a/plone/app/caching/tests/test_integration.py
+++ b/plone/app/caching/tests/test_integration.py
@@ -15,7 +15,7 @@ from plone.cachepurging.interfaces import IPurger
 from plone.caching.interfaces import ICacheSettings
 from plone.namedfile.file import NamedImage
 from plone.registry.interfaces import IRegistry
-from plone.testing.z2 import Browser
+from plone.testing.zope import Browser
 from zope.component import getUtility
 from zope.globalrequest import setRequest
 

--- a/plone/app/caching/tests/test_operation_default.py
+++ b/plone/app/caching/tests/test_operation_default.py
@@ -7,7 +7,7 @@ from plone.app.testing import TEST_USER_NAME
 from plone.app.testing import TEST_USER_PASSWORD
 from plone.caching.interfaces import ICacheSettings
 from plone.registry.interfaces import IRegistry
-from plone.testing.z2 import Browser
+from plone.testing.zope import Browser
 from zope.component import getUtility
 from zope.globalrequest import setRequest
 

--- a/plone/app/caching/tests/test_operation_parameters.py
+++ b/plone/app/caching/tests/test_operation_parameters.py
@@ -7,7 +7,7 @@ from plone.app.testing import TEST_USER_PASSWORD
 from plone.app.textfield.value import RichTextValue
 from plone.caching.interfaces import ICacheSettings
 from plone.registry.interfaces import IRegistry
-from plone.testing.z2 import Browser
+from plone.testing.zope import Browser
 from zope.component import getUtility
 from zope.globalrequest import setRequest
 

--- a/plone/app/caching/tests/test_profile_with_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_with_caching_proxy.py
@@ -16,7 +16,7 @@ from plone.cachepurging.interfaces import ICachePurgingSettings
 from plone.cachepurging.interfaces import IPurger
 from plone.caching.interfaces import ICacheSettings
 from plone.registry.interfaces import IRegistry
-from plone.testing.z2 import Browser
+from plone.testing.zope import Browser
 from Products.CMFCore.FSFile import FSFile
 from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility

--- a/plone/app/caching/tests/test_profile_with_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_with_caching_proxy.py
@@ -69,7 +69,7 @@ class TestProfileWithCaching(unittest.TestCase):
     def tearDown(self):
         setRequest(None)
 
-    def test_composite_viewsxx(self):
+    def test_composite_views(self):
         # This is a clone of the same test for 'without-caching-proxy'
         # Can we just call that test from this context?
 

--- a/plone/app/caching/tests/test_profile_without_caching_proxy.py
+++ b/plone/app/caching/tests/test_profile_without_caching_proxy.py
@@ -13,7 +13,7 @@ from plone.app.textfield.value import RichTextValue
 from plone.cachepurging.interfaces import ICachePurgingSettings
 from plone.caching.interfaces import ICacheSettings
 from plone.registry.interfaces import IRegistry
-from plone.testing.z2 import Browser
+from plone.testing.zope import Browser
 from Products.CMFCore.utils import getToolByName
 from zope.component import getUtility
 from zope.globalrequest import setRequest

--- a/plone/app/caching/tests/test_utils.py
+++ b/plone/app/caching/tests/test_utils.py
@@ -2,6 +2,7 @@
 from Acquisition import Explicit
 from datetime import date
 from datetime import datetime
+from datetime import timedelta
 from plone.app.caching.interfaces import IPloneCacheSettings
 from plone.app.caching.utils import getObjectDefaultView
 from plone.app.caching.utils import isPurged
@@ -28,9 +29,13 @@ TEST_IMAGE = pkg_resources.resource_filename(
 
 def stable_now():
     """Patch localized_now to allow stable results in tests.
+
+    Note that a fixed date is not good enough:
+    several tests compare this date with an Expires header,
+    and this header may be set to ten years ago.
     """
     tzinfo = pytz.timezone(TEST_TIMEZONE)
-    now = datetime(2013, 6, 5, 10, 0, 0).replace(microsecond=0)
+    now = datetime.now() - timedelta(days=1000)
     now = tzinfo.localize(now)  # set tzinfo with correct DST offset
     return now
 


### PR DESCRIPTION
Backported from master.  Fixes issue #127.