### PR TITLE
purge on workflow change

### DIFF
--- a/news/144.feature
+++ b/news/144.feature
@@ -1,0 +1,1 @@
+trigger purge on workflow change @mamico

--- a/news/144.feature
+++ b/news/144.feature
@@ -1,1 +1,1 @@
-trigger purge on workflow change @mamico
+Trigger purge on workflow change. @mamico

--- a/plone/app/caching/configure.zcml
+++ b/plone/app/caching/configure.zcml
@@ -45,6 +45,8 @@
   <!-- Purging -->
   <subscriber handler=".purge.purgeOnModified" />
   <subscriber handler=".purge.purgeOnMovedOrRemoved" />
+  <subscriber handler=".purge.purgeOnWorkflow" />
+
 
   <!-- ILastModified adapters -->
   <adapter factory=".lastmodified.PageTemplateDelegateLastModified" />

--- a/plone/app/caching/purge.py
+++ b/plone/app/caching/purge.py
@@ -259,3 +259,6 @@ def purgeOnMovedOrRemoved(object, event):
 def purgeOnWorkflow(object, event):
     if isPurged(object):
         notify(Purge(object))
+    parent = object.getParentNode()
+    if parent and isPurged(parent):
+        notify(Purge(parent))

--- a/plone/app/caching/purge.py
+++ b/plone/app/caching/purge.py
@@ -9,6 +9,7 @@ from plone.memoize.instance import memoize
 from plone.namedfile.interfaces import INamedBlobFileField
 from plone.namedfile.interfaces import INamedImageField
 from plone.registry.interfaces import IRegistry
+from Products.CMFCore.interfaces import IActionSucceededEvent
 from Products.CMFCore.interfaces import IContentish
 from Products.CMFCore.interfaces import IDiscussionResponse
 from Products.CMFCore.interfaces import IDynamicType
@@ -252,3 +253,9 @@ def purgeOnMovedOrRemoved(object, event):
     parent = object.getParentNode()
     if parent:
         notify(Purge(parent))
+
+
+@adapter(IContentish, IActionSucceededEvent)
+def purgeOnWorkflow(object, event):
+    if isPurged(object):
+        notify(Purge(object))

--- a/plone/app/caching/tests/test_integration.py
+++ b/plone/app/caching/tests/test_integration.py
@@ -272,3 +272,49 @@ class TestOperations(unittest.TestCase):
             },
             set(self.purger._async),
         )
+
+    def test_purge_on_changeworkflow(self):
+        setRoles(self.portal, TEST_USER_ID, ("Manager",))
+
+        # Non-folder content
+        self.portal.invokeFactory("Document", "d1")
+        self.portal["d1"].title = "Document one"
+        self.portal["d1"].description = "Document one description"
+        self.portal.portal_workflow.doActionFor(self.portal["d1"], "publish")
+
+        self.assertEqual([], self.purger._sync)
+        self.assertEqual([], self.purger._async)
+
+        # Enable purge
+        self.cachePurgingSettings.enabled = True
+        self.cachePurgingSettings.cachingProxies = ("http://localhost:1234",)
+        self.ploneCacheSettings.purgedContentTypes = ("Document",)
+
+        url = self.portal["d1"].absolute_url()
+        token = getToken(TEST_USER_NAME)
+        retractURL = f"{url}/content_status_modify?workflow_action=retract&_authenticator={token}"
+
+        import transaction
+
+        transaction.commit()
+
+        browser = Browser(self.app)
+        browser.handleErrors = False
+        browser.addHeader(
+            "Authorization",
+            f"Basic {TEST_USER_NAME}:{TEST_USER_PASSWORD}",
+        )
+
+        # Retract the document
+        browser.open(retractURL)
+
+        self.assertEqual([], self.purger._sync)
+        self.assertEqual(
+            {
+                "http://localhost:1234/plone/d1",
+                "http://localhost:1234/plone/d1/document_view",
+                "http://localhost:1234/plone/d1/",
+                "http://localhost:1234/plone/d1/view",
+            },
+            set(self.purger._async),
+        )


### PR DESCRIPTION
Trigger the purge even when the workflow changes. The issue arises, for example, when content is unpublished and therefore needs to be removed from the external cache.